### PR TITLE
Enable multiple beneficiaries

### DIFF
--- a/contracts/assertive.sol
+++ b/contracts/assertive.sol
@@ -4,4 +4,11 @@ contract Assertive {
             throw;
         }
     }
+    function assertIncreasing(uint[] array) {
+        if (array.length < 2) return;
+
+        for (uint i = 1; i < array.length; i ++) {
+            assert(array[i] > array[i - 1]);
+        }
+    }
 }

--- a/contracts/auction_manager.sol
+++ b/contracts/auction_manager.sol
@@ -411,6 +411,7 @@ contract AuctionManager is AuctionUser, EventfulManager {
     }
     function _checkPayouts(Auction A) internal {
         assert(A.beneficiaries.length == A.payouts.length);
+        if (!A.reversed) assert(A.payouts[0] >= A.start_bid);
         assert(cumsum(A.payouts)[A.payouts.length -1] == A.collection_limit);
     }
     function _newTwoWayAuction( address creator

--- a/contracts/auction_manager.sol
+++ b/contracts/auction_manager.sol
@@ -409,6 +409,33 @@ contract AuctionManager is AuctionUser, EventfulManager {
                                   reversed: false
                                   });
     }
+    function newTwoWayAuction( address[] beneficiaries
+                             , uint[] payouts
+                             , ERC20 selling
+                             , ERC20 buying
+                             , uint sell_amount
+                             , uint start_bid
+                             , uint min_increase
+                             , uint min_decrease
+                             , uint duration
+                             , uint collection_limit
+                             )
+        returns (uint, uint)
+    {
+        return _newTwoWayAuction({creator: msg.sender,
+                                  beneficiaries: beneficiaries,
+                                  payouts: payouts,
+                                  selling: selling,
+                                  buying: buying,
+                                  sell_amount: sell_amount,
+                                  start_bid: start_bid,
+                                  min_increase: min_increase,
+                                  min_decrease: min_decrease,
+                                  duration: duration,
+                                  collection_limit: collection_limit,
+                                  reversed: false
+                                  });
+    }
     function _checkPayouts(Auction A) internal {
         assert(A.beneficiaries.length == A.payouts.length);
         if (!A.reversed) assert(A.payouts[0] >= A.start_bid);

--- a/contracts/auction_manager.sol
+++ b/contracts/auction_manager.sol
@@ -266,8 +266,13 @@ contract AuctionManager is AuctionUser, EventfulManager {
                         )
         returns (uint auction_id, uint base_id)
     {
+        address[] memory beneficiaries = new address[](1);
+        beneficiaries[0] = beneficiary;
+        uint[] memory limits = new uint[](1);
+
         (auction_id, base_id) = _newTwoWayAuction({creator: msg.sender,
-                                                   beneficiary: beneficiary,
+                                                   beneficiaries: beneficiaries,
+                                                   limits: limits,
                                                    selling: selling,
                                                    buying: buying,
                                                    sell_amount: sell_amount,
@@ -289,10 +294,15 @@ contract AuctionManager is AuctionUser, EventfulManager {
                               )
         returns (uint auction_id, uint base_id)
     {
+        address[] memory beneficiaries = new address[](1);
+        beneficiaries[0] = beneficiary;
+        uint[] memory limits = new uint[](1);
+
         // the Reverse Auction is the limit of the two way auction
         // where the maximum collected buying token is zero.
         (auction_id, base_id) = _newTwoWayAuction({creator: msg.sender,
-                                                   beneficiary: beneficiary,
+                                                   beneficiaries: beneficiaries,
+                                                   limits: limits,
                                                    selling: selling,
                                                    buying: buying,
                                                    sell_amount: max_sell_amount,
@@ -318,8 +328,13 @@ contract AuctionManager is AuctionUser, EventfulManager {
                              )
         returns (uint, uint)
     {
+        address[] memory beneficiaries = new address[](1);
+        beneficiaries[0] = beneficiary;
+        uint[] memory limits = new uint[](1);
+
         return _newTwoWayAuction({creator: msg.sender,
-                                  beneficiary: beneficiary,
+                                  beneficiaries: beneficiaries,
+                                  limits: limits,
                                   selling: selling,
                                   buying: buying,
                                   sell_amount: sell_amount,
@@ -331,7 +346,8 @@ contract AuctionManager is AuctionUser, EventfulManager {
                                   });
     }
     function _newTwoWayAuction( address creator
-                              , address beneficiary
+                              , address[] beneficiaries
+                              , uint[] limits
                               , ERC20 selling
                               , ERC20 buying
                               , uint sell_amount
@@ -344,11 +360,10 @@ contract AuctionManager is AuctionUser, EventfulManager {
         internal
         returns (uint, uint)
     {
-        address[] memory beneficiaries = new address[](1);
-        beneficiaries[0] = beneficiary;
         Auction memory A;
         A.creator = creator;
         A.beneficiaries = beneficiaries;
+        A.limits = limits;
         A.selling = selling;
         A.buying = buying;
         A.sell_amount = sell_amount;

--- a/contracts/auction_manager.sol
+++ b/contracts/auction_manager.sol
@@ -384,6 +384,8 @@ contract AuctionManager is AuctionUser, EventfulManager {
         internal
         returns (uint, uint)
     {
+        assert(beneficiaries.length == limits.length);
+
         Auction memory A;
         A.creator = creator;
         A.beneficiaries = beneficiaries;

--- a/contracts/auction_manager.sol
+++ b/contracts/auction_manager.sol
@@ -283,6 +283,30 @@ contract AuctionManager is AuctionUser, EventfulManager {
                                                    collection_limit: INFINITY
                                                  });
     }
+    function newAuction( address[] beneficiaries
+                       , uint[] limits
+                       , ERC20 selling
+                       , ERC20 buying
+                       , uint sell_amount
+                       , uint start_bid
+                       , uint min_increase
+                       , uint duration
+                       )
+        returns (uint auction_id, uint base_id)
+    {
+        (auction_id, base_id) = _newTwoWayAuction({creator: msg.sender,
+                                                   beneficiaries: beneficiaries,
+                                                   limits: limits,
+                                                   selling: selling,
+                                                   buying: buying,
+                                                   sell_amount: sell_amount,
+                                                   start_bid: start_bid,
+                                                   min_increase: min_increase,
+                                                   min_decrease: 0,
+                                                   duration: duration,
+                                                   collection_limit: INFINITY
+                                                 });
+    }
     // Create a new reverse auction
     function newReverseAuction( address beneficiary
                               , ERC20 selling

--- a/contracts/auction_manager.sol
+++ b/contracts/auction_manager.sol
@@ -385,6 +385,7 @@ contract AuctionManager is AuctionUser, EventfulManager {
         returns (uint, uint)
     {
         assert(beneficiaries.length == limits.length);
+        assertIncreasing(limits);
 
         Auction memory A;
         A.creator = creator;

--- a/contracts/auction_manager.sol
+++ b/contracts/auction_manager.sol
@@ -269,6 +269,7 @@ contract AuctionManager is AuctionUser, EventfulManager {
         address[] memory beneficiaries = new address[](1);
         beneficiaries[0] = beneficiary;
         uint[] memory limits = new uint[](1);
+        limits[0] = 0;
 
         (auction_id, base_id) = _newTwoWayAuction({creator: msg.sender,
                                                    beneficiaries: beneficiaries,
@@ -321,6 +322,7 @@ contract AuctionManager is AuctionUser, EventfulManager {
         address[] memory beneficiaries = new address[](1);
         beneficiaries[0] = beneficiary;
         uint[] memory limits = new uint[](1);
+        limits[0] = 0;
 
         // the Reverse Auction is the limit of the two way auction
         // where the maximum collected buying token is zero.
@@ -355,6 +357,7 @@ contract AuctionManager is AuctionUser, EventfulManager {
         address[] memory beneficiaries = new address[](1);
         beneficiaries[0] = beneficiary;
         uint[] memory limits = new uint[](1);
+        limits[0] = 0;
 
         return _newTwoWayAuction({creator: msg.sender,
                                   beneficiaries: beneficiaries,
@@ -386,7 +389,7 @@ contract AuctionManager is AuctionUser, EventfulManager {
     {
         assert(beneficiaries.length == limits.length);
         assertIncreasing(limits);
-        assert(limits[0] >= start_bid);
+        assert(limits[0] == 0);
 
         Auction memory A;
         A.creator = creator;

--- a/contracts/auction_manager.sol
+++ b/contracts/auction_manager.sol
@@ -424,10 +424,10 @@ contract AuctionManager is AuctionUser, EventfulManager {
                              , uint min_increase
                              , uint min_decrease
                              , uint duration
-                             , uint collection_limit
                              )
         returns (uint, uint)
     {
+        var collection_limit = sum(payouts);
         return _newTwoWayAuction({creator: msg.sender,
                                   beneficiaries: beneficiaries,
                                   payouts: payouts,

--- a/contracts/auction_manager.sol
+++ b/contracts/auction_manager.sol
@@ -445,7 +445,7 @@ contract AuctionManager is AuctionUser, EventfulManager {
     function _checkPayouts(Auction A) internal {
         assert(A.beneficiaries.length == A.payouts.length);
         if (!A.reversed) assert(A.payouts[0] >= A.start_bid);
-        assert(cumsum(A.payouts)[A.payouts.length -1] == A.collection_limit);
+        assert(sum(A.payouts) == A.collection_limit);
     }
     function _newTwoWayAuction( address creator
                               , address[] beneficiaries

--- a/contracts/auction_manager.sol
+++ b/contracts/auction_manager.sol
@@ -21,6 +21,7 @@ contract AuctionTypes {
     struct Auction {
         address creator;
         address[] beneficiaries;
+        uint[] limits;
         ERC20 selling;
         ERC20 buying;
         uint start_bid;

--- a/contracts/auction_manager.sol
+++ b/contracts/auction_manager.sol
@@ -20,6 +20,12 @@ contract MathUser {
         }
         return out;
     }
+    function sum(uint[] array) internal returns (uint total) {
+        total = 0;
+        for (uint i = 0; i < array.length; i++) {
+            total += array[i];
+        }
+    }
 }
 
 contract EventfulAuction {

--- a/contracts/auction_manager.sol
+++ b/contracts/auction_manager.sol
@@ -386,6 +386,7 @@ contract AuctionManager is AuctionUser, EventfulManager {
     {
         assert(beneficiaries.length == limits.length);
         assertIncreasing(limits);
+        assert(limits[0] >= start_bid);
 
         Auction memory A;
         A.creator = creator;

--- a/contracts/auction_manager_test.sol
+++ b/contracts/auction_manager_test.sol
@@ -520,16 +520,19 @@ contract AssertionTest is Test, Assertive() {
 }
 
 contract MathTest is Test, MathUser {
+    uint[] array;
+    function setUp() {
+        uint[] memory _array = new uint[](3);
+        _array[0] = 1;
+        _array[1] = 3;
+        _array[2] = 0;
+        array = _array;
+    }
     function testFlat() {
         assertEq(0, flat(1, 2));
         assertEq(1, flat(2, 1));
     }
     function testCumSum() {
-        uint[] memory array = new uint[](3);
-        array[0] = 1;
-        array[1] = 3;
-        array[2] = 0;
-
         uint[] memory expected = new uint[](3);
         expected[0] = 1;
         expected[1] = 4;
@@ -539,5 +542,11 @@ contract MathTest is Test, MathUser {
         for (uint i = 0; i < array.length; i++) {
             assertEq(expected[i], found[i]);
         }
+    }
+    function testSum() {
+        assertEq(4, sum(array));
+    }
+    function testSumEquivalentCumSum() {
+        assertEq(cumsum(array)[2], sum(array));
     }
 }

--- a/contracts/auction_manager_test.sol
+++ b/contracts/auction_manager_test.sol
@@ -415,10 +415,10 @@ contract MultipleBeneficiariesTest is Test, EventfulAuction, EventfulManager {
         t2.approve(manager, 1000 * T2);
     }
     function testNewAuction() {
-        address[] memory beneficiaries = new address[](2);
+        address[] memory beneficiaries = new address[](1);
         beneficiaries[0] = beneficiary1;
 
-        uint[] memory limits = new uint[](2);
+        uint[] memory limits = new uint[](1);
 
         var (id1, base1) = manager.newAuction(beneficiary1, t1, t2, 100 * T1, 0 * T2, 1 * T2, 1 years);
         var (id2, base2) = manager.newAuction(beneficiaries, limits, t1, t2, 100 * T1, 0 * T2, 1 * T2, 1 years);
@@ -438,6 +438,20 @@ contract MultipleBeneficiariesTest is Test, EventfulAuction, EventfulManager {
         beneficiaries[0] = beneficiary1;
 
         uint[] memory limits = new uint[](3);
+        limits[0] = 0;
+        limits[1] = 1;
+        limits[2] = 2;
+
+        var (id2, base2) = manager.newAuction(beneficiaries, limits, t1, t2, 100 * T1, 0 * T2, 1 * T2, 1 years);
+    }
+    function testFailNonIncreasingLimits() {
+        address[] memory beneficiaries = new address[](3);
+        beneficiaries[0] = beneficiary1;
+
+        uint[] memory limits = new uint[](3);
+        limits[0] = 0;
+        limits[1] = 2;
+        limits[2] = 1;
 
         var (id2, base2) = manager.newAuction(beneficiaries, limits, t1, t2, 100 * T1, 0 * T2, 1 * T2, 1 years);
     }

--- a/contracts/auction_manager_test.sol
+++ b/contracts/auction_manager_test.sol
@@ -518,3 +518,26 @@ contract AssertionTest is Test, Assertive() {
         assertIncreasing(array);
     }
 }
+
+contract MathTest is Test, MathUser {
+    function testFlat() {
+        assertEq(0, flat(1, 2));
+        assertEq(1, flat(2, 1));
+    }
+    function testCumSum() {
+        uint[] memory array = new uint[](3);
+        array[0] = 1;
+        array[1] = 3;
+        array[2] = 0;
+
+        uint[] memory expected = new uint[](3);
+        expected[0] = 1;
+        expected[1] = 4;
+        expected[2] = 4;
+
+        var found = cumsum(array);
+        for (uint i = 0; i < array.length; i++) {
+            assertEq(expected[i], found[i]);
+        }
+    }
+}

--- a/contracts/auction_manager_test.sol
+++ b/contracts/auction_manager_test.sol
@@ -455,12 +455,12 @@ contract MultipleBeneficiariesTest is Test, EventfulAuction, EventfulManager {
 
         var (id2, base2) = manager.newAuction(beneficiaries, limits, t1, t2, 100 * T1, 0 * T2, 1 * T2, 1 years);
     }
-    function testFailLimitLowerThanStartBid() {
+    function testFailNonZeroLowerLimit() {
         address[] memory beneficiaries = new address[](1);
         beneficiaries[0] = beneficiary1;
 
         uint[] memory limits = new uint[](1);
-        limits[0] = 0;
+        limits[0] = 1;
 
         var (id2, base2) = manager.newAuction(beneficiaries, limits, t1, t2, 100 * T1, 1 * T2, 1 * T2, 1 years);
     }

--- a/contracts/auction_manager_test.sol
+++ b/contracts/auction_manager_test.sol
@@ -433,4 +433,12 @@ contract MultipleBeneficiariesTest is Test, EventfulAuction, EventfulManager {
 
         assertEq(beneficiary, beneficiary1);
     }
+    function testFailUnequalLimitsLength() {
+        address[] memory beneficiaries = new address[](2);
+        beneficiaries[0] = beneficiary1;
+
+        uint[] memory limits = new uint[](3);
+
+        var (id2, base2) = manager.newAuction(beneficiaries, limits, t1, t2, 100 * T1, 0 * T2, 1 * T2, 1 years);
+    }
 }

--- a/contracts/auction_manager_test.sol
+++ b/contracts/auction_manager_test.sol
@@ -456,6 +456,17 @@ contract MultipleBeneficiariesTest is Test, EventfulAuction, EventfulManager {
 
         var (id2, base2) = manager.newAuction(beneficiaries, payouts, t1, t2, 100 * T1, 0 * T2, 1 * T2, 1 years);
     }
+    function testFailFirstPayoutLessThanStartBid() {
+        address[] memory beneficiaries = new address[](2);
+        beneficiaries[0] = beneficiary1;
+        beneficiaries[1] = beneficiary2;
+
+        uint[] memory payouts = new uint[](2);
+        payouts[0] = 10 * T2;
+        payouts[1] = INFINITY - 10 * T2;
+
+        var (id, base) = manager.newAuction(beneficiaries, payouts, t1, t2, 100 * T1, 50 * T2, 1 * T2, 1 years);
+    }
     function testPayoutFirstBeneficiary() {
         address[] memory beneficiaries = new address[](2);
         beneficiaries[0] = beneficiary1;

--- a/contracts/auction_manager_test.sol
+++ b/contracts/auction_manager_test.sol
@@ -83,14 +83,17 @@ contract AuctionManagerTest is Test, EventfulAuction, EventfulManager {
         assertEq(t2.balanceOf(bidder1), 1000 * T2);
         assertEq(t2.allowance(bidder1, manager), 1000 * T2);
     }
+    function newAuction() returns (uint, uint) {
+        return manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 1 * T2, 1 years);
+    }
     function testNewAuctionEvent() {
-        var (id, base) = manager.newAuction(seller, t1, t2, 100 * T1, 0 * T2, 1 * T2, 1 years);
+        var (id, base) = newAuction();
 
         expectEventsExact(manager);
         NewAuction(id, base);
     }
     function testBidEvent() {
-        var (id, base) = manager.newAuction(seller, t1, t2, 100 * T1, 0 * T2, 1 * T2, 1 years);
+        var (id, base) = newAuction();
         bidder1.doBid(base, 11 * T2);
         bidder2.doBid(base, 12 * T2);
 
@@ -100,14 +103,7 @@ contract AuctionManagerTest is Test, EventfulAuction, EventfulManager {
         Bid(base);
     }
     function testNewAuction() {
-        var (id, base) = manager.newAuction(seller,  // beneficiary
-                                            t1,      // selling
-                                            t2,      // buying
-                                            100 * T1,// sell amount (t1)
-                                            0 * T2,  // minimum bid (t2)
-                                            1 * T2,  // minimum increase
-                                            1 years  // duration
-                                           );
+        var (id, base) = newAuction();
         assertEq(id, 1);
 
         var (beneficiary, selling, buying,
@@ -117,26 +113,26 @@ contract AuctionManagerTest is Test, EventfulAuction, EventfulManager {
         assertTrue(selling == t1);
         assertTrue(buying == t2);
         assertEq(sell_amount, 100 * T1);
-        assertEq(start_bid, 0 * T2);
+        assertEq(start_bid, 10 * T2);
         assertEq(min_increase, 1 * T2);
         assertEq(expiration, manager.getTime() + 1 years);
     }
     function testNewAuctionTransfersToManager() {
         var balance_before = t1.balanceOf(manager);
-        manager.newAuction(seller, t1, t2, 100 * T1, 0 * T2, 1 * T2, 1 years);
+        newAuction();
         var balance_after = t1.balanceOf(manager);
 
         assertEq(balance_after - balance_before, 100 * T1);
     }
     function testNewAuctionTransfersFromCreator() {
         var balance_before = t1.balanceOf(this);
-        var (id, base) = manager.newAuction(bidder2, t1, t2, 100 * T1, 0 * T2, 1 * T2, 1 years);
+        var (id, base) = newAuction();
         var balance_after = t1.balanceOf(this);
 
         assertEq(balance_before - balance_after, 100 * T1);
     }
     function testNewAuctionlet() {
-        var (id, base) = manager.newAuction(seller, t1, t2, 100 * T1, 0 * T2, 1 * T2, 1 years);
+        var (id, base) = newAuction();
 
         // can't always know what the auctionlet id is as it is
         // only an internal type. But for the case of a single auction
@@ -146,20 +142,20 @@ contract AuctionManagerTest is Test, EventfulAuction, EventfulManager {
 
         assertEq(auction_id, id);
         assertEq(last_bidder, seller);
-        assertEq(buy_amount, 0 * T2);
+        assertEq(buy_amount, 10 * T2);
         assertEq(sell_amount, 100 * T1);
     }
     function testFailBidUnderMinBid() {
-        var (id, base) = manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 1 * T2, 1 years);
+        var (id, base) = newAuction();
         bidder1.doBid(base, 9 * T2);
     }
     function testFailBidUnderMinIncrease() {
-        var (id, base) = manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 2 * T2, 1 years);
+        var (id, base) = newAuction();
         bidder1.doBid(base, 10 * T2);
         bidder2.doBid(base, 11 * T2);
     }
     function testBid() {
-        var (id, base) = manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 1 * T2, 1 years);
+        var (id, base) = newAuction();
         bidder1.doBid(base, 11 * T2);
 
         var (auction_id, last_bidder1,
@@ -169,13 +165,13 @@ contract AuctionManagerTest is Test, EventfulAuction, EventfulManager {
         assertEq(buy_amount, 11 * T2);
     }
     function testFailBidTransfer() {
-        var (id, base) = manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 1 * T2, 1 years);
+        var (id, base) = newAuction();
 
         // this should throw as bidder1 only has 1000 t2
         bidder1.doBid(base, 1001 * T2);
     }
     function testBidTransfer() {
-        var (id, base) = manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 1 * T2, 1 years);
+        var (id, base) = newAuction();
 
         var bidder1_t2_balance_before = t2.balanceOf(bidder1);
         bidder1.doBid(base, 11 * T2);
@@ -185,7 +181,7 @@ contract AuctionManagerTest is Test, EventfulAuction, EventfulManager {
         assertEq(balance_diff, 11 * T2);
     }
     function testBidReturnsToPrevBidder() {
-        var (id, base) = manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 1 * T2, 1 years);
+        var (id, base) = newAuction();
 
         var bidder1_t2_balance_before = t2.balanceOf(bidder1);
         bidder1.doBid(base, 11 * T2);
@@ -196,7 +192,7 @@ contract AuctionManagerTest is Test, EventfulAuction, EventfulManager {
         assertEq(bidder_balance_diff, 0 * T2);
     }
     function testFailBidExpired() {
-        var (id, base) = manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 1 * T2, 1 years);
+        var (id, base) = newAuction();
         bidder1.doBid(base, 11 * T2);
 
         // force expiry
@@ -205,7 +201,7 @@ contract AuctionManagerTest is Test, EventfulAuction, EventfulManager {
         bidder2.doBid(base, 12 * T2);
     }
     function testBidTransfersBenefactor() {
-        var (id, base) = manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 1 * T2, 1 years);
+        var (id, base) = newAuction();
 
         var balance_before = t2.balanceOf(seller);
         bidder1.doBid(base, 40 * T2);
@@ -217,7 +213,7 @@ contract AuctionManagerTest is Test, EventfulAuction, EventfulManager {
         var bidder_t2_balance_before = t2.balanceOf(bidder1);
         var bidder_t1_balance_before = t1.balanceOf(bidder1);
 
-        var (id, base) = manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 1 * T2, 1 years);
+        var (id, base) = newAuction();
         bidder1.doBid(base, 11 * T2);
 
         // force expiry
@@ -236,7 +232,7 @@ contract AuctionManagerTest is Test, EventfulAuction, EventfulManager {
         assertEq(diff_t1, 100 * T1);
     }
     function testFailClaimNonParty() {
-        var (id, base) = manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 1 * T2, 1 years);
+        var (id, base) = newAuction();
         bidder1.doBid(base, 11 * T2);
         // bidder2 is not party to the auction and should not be able to
         // initiate a claim
@@ -245,7 +241,7 @@ contract AuctionManagerTest is Test, EventfulAuction, EventfulManager {
     function testFailClaimProceedingsPreExpiration() {
         // bidders cannot claim their auctionlet until the auction has
         // expired.
-        var (id, base) = manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 1 * T2, 1 years);
+        var (id, base) = newAuction();
         bidder1.doBid(base, 11 * T2);
         bidder1.doClaim(1);
     }
@@ -257,7 +253,8 @@ contract AuctionManagerTest is Test, EventfulAuction, EventfulManager {
         var t1_balance_before = t1.balanceOf(this);
         var t2_balance_before = t2.balanceOf(this);
 
-        var (id1, base1) = manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 1 * T2, 1 years);
+        var (id1, base1) = newAuction();
+        // flip tokens around
         var (id2, base2) = manager.newAuction(seller, t2, t1, 100 * T2, 10 * T1, 1 * T1, 1 years);
 
         assertEq(id1, 1);
@@ -278,8 +275,8 @@ contract AuctionManagerTest is Test, EventfulAuction, EventfulManager {
         assertEq(expiration, manager.getTime() + 1 years);
     }
     function testMultipleAuctionsBidTransferToBenefactor() {
-        var (id1, base1) = manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 1 * T2, 1 years);
-        var (id2, base2) = manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 1 * T2, 1 years);
+        var (id1, base1) = newAuction();
+        var (id2, base2) = newAuction();
 
         var seller_t2_balance_before = t2.balanceOf(seller);
 
@@ -295,8 +292,8 @@ contract AuctionManagerTest is Test, EventfulAuction, EventfulManager {
     function testMultipleAuctionsTransferFromCreator() {
         var balance_before = t1.balanceOf(this);
 
-        var (id1, base1) = manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 1 * T2, 1 years);
-        var (id2, base2) = manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 1 * T2, 1 years);
+        var (id1, base1) = newAuction();
+        var (id2, base2) = newAuction();
 
         var balance_after = t1.balanceOf(this);
 
@@ -306,8 +303,8 @@ contract AuctionManagerTest is Test, EventfulAuction, EventfulManager {
         // bidders should not be able to claim their auctionlet more than once
 
         // create an auction that expires immediately
-        var (id1, base1) = manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 1 * T2, 0 years);
-        var (id2, base2) = manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 1 * T2, 0 years);
+        var (id1, base1) = newAuction();
+        var (id2, base2) = newAuction();
 
         // create bids on two different auctions so that the manager has
         // enough funds for us to attempt to withdraw all at once
@@ -322,7 +319,7 @@ contract AuctionManagerTest is Test, EventfulAuction, EventfulManager {
     function testReclaimAfterExpiry() {
         // the seller should be able to reclaim any unbid on
         // sell token after the auction has expired.
-        var (id, base) = manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 1 * T2, 1 years);
+        var (id, base) = newAuction();
 
         // force expiry
         manager.setTime(manager.getTime() + 2 years);
@@ -334,7 +331,7 @@ contract AuctionManagerTest is Test, EventfulAuction, EventfulManager {
         assertEq(balance_after - balance_before, 100 * T1);
     }
     function testFailReclaimBeforeExpiry() {
-        var (id, base) = manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 1 * T2, 1 years);
+        var (id, base) = newAuction();
         seller.doReclaim(id);
     }
     function testBidTransfersToDistinctBeneficiary() {
@@ -347,8 +344,8 @@ contract AuctionManagerTest is Test, EventfulAuction, EventfulManager {
         assertEq(balance_after - balance_before, 10 * T2);
     }
     function testReclaimOnlyOnce() {
-        var (id1, base1) = manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 1 * T2, 1 years);
-        var (id2, base2) = manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 1 * T2, 1 years);
+        var (id1, base1) = newAuction();
+        var (id2, base2) = newAuction();
 
         // force expiry
         manager.setTime(manager.getTime() + 2 years);

--- a/contracts/auction_manager_test.sol
+++ b/contracts/auction_manager_test.sol
@@ -442,3 +442,29 @@ contract MultipleBeneficiariesTest is Test, EventfulAuction, EventfulManager {
         var (id2, base2) = manager.newAuction(beneficiaries, limits, t1, t2, 100 * T1, 0 * T2, 1 * T2, 1 years);
     }
 }
+
+contract AssertionTest is Test, Assertive() {
+    function testAssert() {
+        assert(2 > 1);
+    }
+    function testFailAssert() {
+        assert(2 < 1);
+    }
+    function testIncreasingNoop() {
+        uint[] memory array = new uint[](1);
+        array[0] = 1;
+        assertIncreasing(array);
+    }
+    function testIncreasing() {
+        uint[] memory array = new uint[](2);
+        array[0] = 1;
+        array[1] = 2;
+        assertIncreasing(array);
+    }
+    function testFailIncreasing() {
+        uint[] memory array = new uint[](2);
+        array[0] = 2;
+        array[1] = 1;
+        assertIncreasing(array);
+    }
+}

--- a/contracts/auction_manager_test.sol
+++ b/contracts/auction_manager_test.sol
@@ -380,6 +380,7 @@ contract MultipleBeneficiariesTest is Test, EventfulAuction, EventfulManager {
     // use prime numbers to avoid coincidental collisions
     uint constant T1 = 5 ** 12;
     uint constant T2 = 7 ** 10;
+    uint constant INFINITY = uint(-1);
 
     function setUp() {
         manager = new TestableManager();
@@ -419,10 +420,11 @@ contract MultipleBeneficiariesTest is Test, EventfulAuction, EventfulManager {
         address[] memory beneficiaries = new address[](1);
         beneficiaries[0] = beneficiary1;
 
-        uint[] memory limits = new uint[](1);
+        uint[] memory payouts = new uint[](1);
+        payouts[0] = INFINITY;
 
         var (id1, base1) = manager.newAuction(beneficiary1, t1, t2, 100 * T1, 0 * T2, 1 * T2, 1 years);
-        var (id2, base2) = manager.newAuction(beneficiaries, limits, t1, t2, 100 * T1, 0 * T2, 1 * T2, 1 years);
+        var (id2, base2) = manager.newAuction(beneficiaries, payouts, t1, t2, 100 * T1, 0 * T2, 1 * T2, 1 years);
 
         var (beneficiary, selling, buying,
              sell_amount, start_bid, min_increase, expiration) = manager.getAuction(id1);
@@ -434,47 +436,36 @@ contract MultipleBeneficiariesTest is Test, EventfulAuction, EventfulManager {
 
         assertEq(beneficiary, beneficiary1);
     }
-    function testFailUnequalLimitsLength() {
+    function testFailUnequalPayoutsLength() {
         address[] memory beneficiaries = new address[](2);
         beneficiaries[0] = beneficiary1;
 
-        uint[] memory limits = new uint[](3);
-        limits[0] = 0;
-        limits[1] = 1;
-        limits[2] = 2;
+        uint[] memory payouts = new uint[](1);
+        payouts[0] = INFINITY;
 
-        var (id2, base2) = manager.newAuction(beneficiaries, limits, t1, t2, 100 * T1, 0 * T2, 1 * T2, 1 years);
+        var (id2, base2) = manager.newAuction(beneficiaries, payouts, t1, t2, 100 * T1, 0 * T2, 1 * T2, 1 years);
     }
-    function testFailNonIncreasingLimits() {
+    function testFailNonSummingPayouts() {
         address[] memory beneficiaries = new address[](3);
         beneficiaries[0] = beneficiary1;
 
-        uint[] memory limits = new uint[](3);
-        limits[0] = 0;
-        limits[1] = 2;
-        limits[2] = 1;
+        uint[] memory payouts = new uint[](3);
+        payouts[0] = 0;
+        payouts[1] = 1;
+        payouts[2] = 2;
 
-        var (id2, base2) = manager.newAuction(beneficiaries, limits, t1, t2, 100 * T1, 0 * T2, 1 * T2, 1 years);
-    }
-    function testFailNonZeroLowerLimit() {
-        address[] memory beneficiaries = new address[](1);
-        beneficiaries[0] = beneficiary1;
-
-        uint[] memory limits = new uint[](1);
-        limits[0] = 1;
-
-        var (id2, base2) = manager.newAuction(beneficiaries, limits, t1, t2, 100 * T1, 1 * T2, 1 * T2, 1 years);
+        var (id2, base2) = manager.newAuction(beneficiaries, payouts, t1, t2, 100 * T1, 0 * T2, 1 * T2, 1 years);
     }
     function testPayoutFirstBeneficiary() {
         address[] memory beneficiaries = new address[](2);
         beneficiaries[0] = beneficiary1;
         beneficiaries[1] = beneficiary2;
 
-        uint[] memory limits = new uint[](2);
-        limits[0] = 0 * T2;
-        limits[1] = 10 * T2;
+        uint[] memory payouts = new uint[](2);
+        payouts[0] = 10 * T2;
+        payouts[1] = INFINITY - 10 * T2;
 
-        var (id, base) = manager.newAuction(beneficiaries, limits, t1, t2, 100 * T1, 5 * T2, 1 * T2, 1 years);
+        var (id, base) = manager.newAuction(beneficiaries, payouts, t1, t2, 100 * T1, 5 * T2, 1 * T2, 1 years);
 
         var balance_before = t2.balanceOf(beneficiary1);
         bidder1.doBid(id, 30 * T2);

--- a/contracts/auction_manager_test.sol
+++ b/contracts/auction_manager_test.sol
@@ -359,6 +359,5 @@ contract AuctionManagerTest is Test, EventfulAuction, EventfulManager {
         var balance_after = t1.balanceOf(this);
 
         assertEq(balance_after, balance_before);
-
     }
 }

--- a/contracts/auction_manager_test.sol
+++ b/contracts/auction_manager_test.sol
@@ -455,6 +455,15 @@ contract MultipleBeneficiariesTest is Test, EventfulAuction, EventfulManager {
 
         var (id2, base2) = manager.newAuction(beneficiaries, limits, t1, t2, 100 * T1, 0 * T2, 1 * T2, 1 years);
     }
+    function testFailLimitLowerThanStartBid() {
+        address[] memory beneficiaries = new address[](1);
+        beneficiaries[0] = beneficiary1;
+
+        uint[] memory limits = new uint[](1);
+        limits[0] = 0;
+
+        var (id2, base2) = manager.newAuction(beneficiaries, limits, t1, t2, 100 * T1, 1 * T2, 1 * T2, 1 years);
+    }
 }
 
 contract AssertionTest is Test, Assertive() {

--- a/contracts/auction_manager_test.sol
+++ b/contracts/auction_manager_test.sol
@@ -84,7 +84,14 @@ contract AuctionManagerTest is Test, EventfulAuction, EventfulManager {
         assertEq(t2.allowance(bidder1, manager), 1000 * T2);
     }
     function newAuction() returns (uint, uint) {
-        return manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 1 * T2, 1 years);
+        return manager.newAuction( seller    // beneficiary
+                                 , t1        // selling
+                                 , t2        // buying
+                                 , 100 * T1  // sell_amount
+                                 , 10 * T2   // start_bid
+                                 , 1 * T2    // min_increase
+                                 , 1 years   // duration
+                                 );
     }
     function testNewAuctionEvent() {
         var (id, base) = newAuction();

--- a/contracts/auction_manager_test.sol
+++ b/contracts/auction_manager_test.sol
@@ -372,6 +372,7 @@ contract MultipleBeneficiariesTest is Test, EventfulAuction, EventfulManager {
     AuctionTester bidder1;
     AuctionTester bidder2;
     AuctionTester beneficiary1;
+    AuctionTester beneficiary2;
 
     ERC20 t1;
     ERC20 t2;
@@ -463,6 +464,30 @@ contract MultipleBeneficiariesTest is Test, EventfulAuction, EventfulManager {
         limits[0] = 1;
 
         var (id2, base2) = manager.newAuction(beneficiaries, limits, t1, t2, 100 * T1, 1 * T2, 1 * T2, 1 years);
+    }
+    function testPayoutFirstBeneficiary() {
+        address[] memory beneficiaries = new address[](2);
+        beneficiaries[0] = beneficiary1;
+        beneficiaries[1] = beneficiary2;
+
+        uint[] memory limits = new uint[](2);
+        limits[0] = 0 * T2;
+        limits[1] = 10 * T2;
+
+        var (id, base) = manager.newAuction(beneficiaries, limits, t1, t2, 100 * T1, 5 * T2, 1 * T2, 1 years);
+
+        var balance_before = t2.balanceOf(beneficiary1);
+        bidder1.doBid(id, 30 * T2);
+        var balance_after = t2.balanceOf(beneficiary1);
+
+        assertEq(balance_after - balance_before, 10 * T2);
+    }
+    function testPayoutSecondBeneficiary() {
+        var balance_before = t2.balanceOf(beneficiary2);
+        testPayoutFirstBeneficiary();
+        var balance_after = t2.balanceOf(beneficiary2);
+
+        assertEq(balance_after - balance_before, 20 * T2);
     }
 }
 

--- a/contracts/reverse_splitting_test.sol
+++ b/contracts/reverse_splitting_test.sol
@@ -90,14 +90,14 @@ contract ReverseSplittingTest is Test {
         t2.approve(manager, 1000 * T2);
     }
     function newReverseAuction() returns (uint, uint) {
-        return manager.newReverseAuction({beneficiary: seller,
-                                          selling: t1,
-                                          buying: t2,
-                                          max_sell_amount: 100 * T1,
-                                          buy_amount: 5 * T2,
-                                          min_decrease: 2 * T1,
-                                          duration: 1 years
-                                        });
+        return manager.newReverseAuction( seller    // beneficiary
+                                        , t1        // selling
+                                        , t2        // buying
+                                        , 100 * T1  // sell_amount
+                                        , 5 * T2    // buy_amount
+                                        , 2 * T1    // min_decrease
+                                        , 1 years   // duration
+                                        );
     }
     function testNewReverseAuction() {
         var (id, base) = newReverseAuction();

--- a/contracts/reverse_test.sol
+++ b/contracts/reverse_test.sol
@@ -85,14 +85,14 @@ contract ReverseTest is Test {
         t2.approve(manager, 1000 * T2);
     }
     function newReverseAuction() returns (uint, uint) {
-        return manager.newReverseAuction({beneficiary: seller,
-                                          selling: t1,
-                                          buying: t2,
-                                          max_sell_amount: 100 * T1,
-                                          buy_amount: 5 * T2,
-                                          min_decrease: 2 * T1,
-                                          duration: 1 years
-                                        });
+        return manager.newReverseAuction( seller    // beneficiary
+                                        , t1        // selling
+                                        , t2        // buying
+                                        , 100 * T1  // max_sell_amount
+                                        , 5 * T2    // buy_amount
+                                        , 2 * T1    // min_decrease
+                                        , 1 years   // duration
+                                        );
     }
     function testNewReverseAuction() {
         var (id, base) = newReverseAuction();

--- a/contracts/splitting_auction_test.sol
+++ b/contracts/splitting_auction_test.sol
@@ -92,8 +92,18 @@ contract ForwardSplittingTest is Test
         assertEq(t2.balanceOf(bidder1), 1000 * T2);
         assertEq(t2.allowance(bidder1, manager), 1000 * T2);
     }
+    function newAuction() returns (uint, uint) {
+        return manager.newAuction( seller    // beneficiary
+                                 , t1        // selling
+                                 , t2        // buying
+                                 , 100 * T1  // sell_amount
+                                 , 10 * T2   // start_bid
+                                 , 1 * T2    // min_increase
+                                 , 1 years   // duration
+                                 );
+    }
     function testSplitEvent() {
-        var (id, base) = manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 1 * T2, 1 years);
+        var (id, base) = newAuction();
 
         var (nid1, sid1) = bidder1.doBid(base, 5 * T2, 40 * T1);
         var (nid2, sid2) = bidder2.doBid(nid1, 6 * T2, 40 * T1);
@@ -106,7 +116,7 @@ contract ForwardSplittingTest is Test
         Split(sid1, nid3, sid3);
     }
     function testSplitBase() {
-        var (id, base) = manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 1 * T2, 1 years);
+        var (id, base) = newAuction();
 
         var (auction_id0, last_bidder0,
              buy_amount0, sell_amount0) = manager.getAuctionlet(base);
@@ -130,7 +140,7 @@ contract ForwardSplittingTest is Test
         assertEq(sell_amount1, expected_new_sell_amount);
     }
     function testSplitTransfersFromBidder() {
-        var (id, base) = manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 1 * T2, 1 years);
+        var (id, base) = newAuction();
 
         var balance_before = t2.balanceOf(bidder1);
         bidder1.doBid(base, 7 * T2, 60 * T1);
@@ -139,7 +149,7 @@ contract ForwardSplittingTest is Test
         assertEq(balance_before - balance_after, 7 * T2);
     }
     function testSplitBaseTransfersToSeller() {
-        var (id, base) = manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 1 * T2, 1 years);
+        var (id, base) = newAuction();
 
         var balance_before = t2.balanceOf(seller);
         bidder1.doBid(base, 7 * T2, 60 * T1);
@@ -148,7 +158,7 @@ contract ForwardSplittingTest is Test
         assertEq(balance_after - balance_before, 7 * T2);
     }
     function testSplitTransfersToPrevBidder() {
-        var (id, base) = manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 1 * T2, 1 years);
+        var (id, base) = newAuction();
 
         bidder1.doBid(base, 20 * T2);
 
@@ -159,7 +169,7 @@ contract ForwardSplittingTest is Test
         assertEq(balance_after - balance_before, 10 * T2);
     }
     function testAnotherSplitTransfersToPrevSplitter() {
-        var (id, base) = manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 1 * T2, 1 years);
+        var (id, base) = newAuction();
 
         var (nid, sid) = bidder1.doBid(base, 20 * T2, 80 * T1);
 
@@ -170,7 +180,7 @@ contract ForwardSplittingTest is Test
         assertEq(balance_after - balance_before, 10 * T2);
     }
     function testAnotherSplitTransfersToSeller() {
-        var (id, base) = manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 1 * T2, 1 years);
+        var (id, base) = newAuction();
 
         var (nid, sid) = bidder1.doBid(base, 20 * T2, 80 * T1);
 
@@ -181,7 +191,7 @@ contract ForwardSplittingTest is Test
         assertEq(balance_after - balance_before, 10 * T2);
     }
     function testAnotherSplitTransfersFromSplitter() {
-        var (id, base) = manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 1 * T2, 1 years);
+        var (id, base) = newAuction();
 
         var (nid, sid) = bidder1.doBid(base, 20 * T2, 80 * T1);
 
@@ -192,7 +202,7 @@ contract ForwardSplittingTest is Test
         assertEq(balance_before - balance_after, 20 * T2);
     }
     function testSplitTransfersToSeller() {
-        var (id, base) = manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 1 * T2, 1 years);
+        var (id, base) = newAuction();
 
         var (nid, sid) = bidder1.doBid(base, 20 * T2, 80 * T1);
 
@@ -203,7 +213,7 @@ contract ForwardSplittingTest is Test
         assertEq(balance_after - balance_before, 20 * T2);
     }
     function testBidTransfersToPrevSplitter() {
-        var (id, base) = manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 1 * T2, 1 years);
+        var (id, base) = newAuction();
 
         var (nid, sid) = bidder1.doBid(base, 20 * T2, 80 * T1);
 
@@ -214,7 +224,7 @@ contract ForwardSplittingTest is Test
         assertEq(balance_after - balance_before, 20 * T2);
     }
     function testSplitBaseAddresses() {
-        var (id, base) = manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 1 * T2, 1 years);
+        var (id, base) = newAuction();
 
         var (nid, sid) = bidder1.doBid(base, 7 * T2, 60 * T1);
 
@@ -228,7 +238,7 @@ contract ForwardSplittingTest is Test
         assertEq(last_bidder2, bidder1);
     }
     function testSplitBaseResult() {
-        var (id, base) = manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 1 * T2, 1 years);
+        var (id, base) = newAuction();
 
         var (nid, sid) = bidder1.doBid(base, 5 * T2, 40 * T1);
 
@@ -259,7 +269,7 @@ contract ForwardSplittingTest is Test
         assertEq(buy_amount2, expected_new_bid2);
     }
     function testSplitAfterBidAddresses() {
-        var (id, base) = manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 1 * T2, 1 years);
+        var (id, base) = newAuction();
 
         bidder1.doBid(base, 11 * T2);
 
@@ -276,7 +286,7 @@ contract ForwardSplittingTest is Test
         assertEq(last_bidder2, bidder2);
     }
     function testSplitAfterBidQuantities() {
-        var (id, base) = manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 1 * T2, 1 years);
+        var (id, base) = newAuction();
 
         bidder1.doBid(base, 11 * T2);
 
@@ -321,28 +331,28 @@ contract ForwardSplittingTest is Test
         assertEq(buy_amount2, expected_new_bid2);
     }
     function testFailSplitExcessQuantity() {
-        var (id, base) = manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 1 * T2, 1 years);
+        var (id, base) = newAuction();
         bidder1.doBid(base, 7 * T2, 101 * T1);
     }
     function testPassSplitLowerValue() {
         // The splitting bid must satisfy (b2 / q2) > (b0 / q0)
         // and q2 < q0, i.e. it must be an increase in order valuation,
         // but a decrease in sell_amount.
-        var (id, base) = manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 1 * T2, 1 years);
+        var (id, base) = newAuction();
         bidder1.doBid(base, 6 * T2, 50 * T1);
     }
     function testFailSplitLowerValue() {
         // The splitting bid must satisfy (b2 / q2) > (b0 / q0)
         // and q2 < q0, i.e. it must be an increase in order valuation,
         // but a decrease in sell_amount.
-        var (id, base) = manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 1 * T2, 1 years);
+        var (id, base) = newAuction();
         bidder1.doBid(base, 11 * T2);
 
         bidder2.doBid(base, 5 * T2, 50 * T1);
     }
     function testFailSplitUnderMinBid() {
         // Splitting bids have to be over the scaled minimum bid
-        var (id, base) = manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 1 * T2, 1 years);
+        var (id, base) = newAuction();
         bidder1.doBid(base, 4 * T2, 50 * T1);
     }
     function testFailSplitUnderMinIncrease() {
@@ -354,7 +364,7 @@ contract ForwardSplittingTest is Test
         bidder2.doBid(base, 6 * T2, 50 * T1);
     }
     function testFailSplitExpired() {
-        var (id, base) = manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 1 * T2, 1 years);
+        var (id, base) = newAuction();
         bidder1.doBid(base, 11 * T2);
 
         // force expiry
@@ -363,7 +373,7 @@ contract ForwardSplittingTest is Test
         bidder2.doBid(base, 10 * T2, 50 * T1);
     }
     function testSplitReturnsToPrevBidder() {
-        var (id, base) = manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 1 * T2, 1 years);
+        var (id, base) = newAuction();
 
         var bidder1_t2_balance_before = t2.balanceOf(bidder1);
         bidder1.doBid(base, 20 * T2);
@@ -375,7 +385,7 @@ contract ForwardSplittingTest is Test
     }
     function testSplitBaseTransfersToBenefactor() {
 
-        var (id, base) = manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 1 * T2, 1 years);
+        var (id, base) = newAuction();
 
         var balance_before = t2.balanceOf(seller);
         bidder2.doBid(base, 20 * T2, 25 * T1);
@@ -384,7 +394,7 @@ contract ForwardSplittingTest is Test
         assertEq(balance_after - balance_before, 20 * T2);
     }
     function testSplitTransfersBenefactor() {
-        var (id, base) = manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 1 * T2, 1 years);
+        var (id, base) = newAuction();
 
         var balance_before = t2.balanceOf(seller);
         bidder1.doBid(base, 40 * T2);
@@ -397,19 +407,19 @@ contract ForwardSplittingTest is Test
     function testFailBidAfterSplit() {
         // splitting deletes the old auctionlet_id
         // bidding on this id should error
-        var (id, base) = manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 1 * T2, 1 years);
+        var (id, base) = newAuction();
         var (nid, sid) = bidder2.doBid(base, 12 * T2, 60 * T1);
         bidder1.doBid(base, 11 * T2);
     }
     function testFailSplitAfterSplit() {
         // splitting deletes the old auctionlet_id
         // splitting on this id should error
-        var (id, base) = manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 1 * T2, 1 years);
+        var (id, base) = newAuction();
         var (nid, sid) = bidder2.doBid(base, 12 * T2, 60 * T1);
         bidder1.doBid(base, 20 * T2, 60 * T1);
     }
     function testReclaimAfterBaseSplit() {
-        var (id, base) = manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 1 * T2, 1 years);
+        var (id, base) = newAuction();
 
         bidder1.doBid(base, 20 * T2, 50 * T1);
         // force expiry
@@ -422,7 +432,7 @@ contract ForwardSplittingTest is Test
         assertEq(balance_after - balance_before, 50 * T1);
     }
     function testReclaimAfterSplitBaseSplit() {
-        var (id, base) = manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 1 * T2, 1 years);
+        var (id, base) = newAuction();
 
         var (nid, sid) = bidder1.doBid(base, 20 * T2, 50 * T1);
         bidder2.doBid(sid, 20 * T2, 40 * T1);

--- a/contracts/twoway_test.sol
+++ b/contracts/twoway_test.sol
@@ -101,7 +101,7 @@ contract TwoWayTest is Test, EventfulAuction, EventfulManager {
     }
     function testReversalEvent() {
         var (id, base) = newTwoWayAuction();
-        bidder1.doBid(1, 101 * T2);
+        bidder1.doBid(base, 101 * T2);
 
         expectEventsExact(manager);
         NewAuction(id, base);
@@ -115,19 +115,19 @@ contract TwoWayTest is Test, EventfulAuction, EventfulManager {
     function testBidEqualTargetNoReversal() {
         // bids at the target should not cause the auction to reverse
         var (id, base) = newTwoWayAuction();
-        bidder1.doBid(1, 100 * T2);
+        bidder1.doBid(base, 100 * T2);
         assertEq(manager.isReversed(id), false);
     }
     function testBidOverTargetReversal() {
         // bids over the target should cause the auction to reverse
         var (id, base) = newTwoWayAuction();
-        bidder1.doBid(1, 101 * T2);
+        bidder1.doBid(base, 101 * T2);
         assertEq(manager.isReversed(id), true);
     }
     function testBidOverTargetRefundsDifference() {
         var (id, base) = newTwoWayAuction();
         var t2_balance_before = t2.balanceOf(bidder1);
-        bidder1.doBid(1, 110 * T2);
+        bidder1.doBid(base, 110 * T2);
         var t2_balance_after = t2.balanceOf(bidder1);
 
         var balance_diff = t2_balance_before - t2_balance_after;
@@ -135,7 +135,7 @@ contract TwoWayTest is Test, EventfulAuction, EventfulManager {
     }
     function testBidOverTargetSetsReverseBidder() {
         var (id, base) = newTwoWayAuction();
-        bidder1.doBid(1, 110 * T2);
+        bidder1.doBid(base, 110 * T2);
 
         var (auction_id, last_bidder,
              buy_amount, sell_amount) = manager.getAuctionlet(base);
@@ -144,7 +144,7 @@ contract TwoWayTest is Test, EventfulAuction, EventfulManager {
     }
     function testBidOverTargetSetsReverseBuyAmount() {
         var (id, base) = newTwoWayAuction();
-        bidder1.doBid(1, 110 * T2);
+        bidder1.doBid(base, 110 * T2);
 
         var (auction_id, last_bidder,
              buy_amount, sell_amount) = manager.getAuctionlet(base);
@@ -153,7 +153,7 @@ contract TwoWayTest is Test, EventfulAuction, EventfulManager {
     }
     function testBidOverTargetSetsReverseBid() {
         var (id, base) = newTwoWayAuction();
-        bidder1.doBid(1, 110 * T2);
+        bidder1.doBid(base, 110 * T2);
 
         var (auction_id, last_bidder,
              buy_amount, sell_amount) = manager.getAuctionlet(base);
@@ -170,18 +170,18 @@ contract TwoWayTest is Test, EventfulAuction, EventfulManager {
     }
     function testBaseSplitEqualTargetNoReversal() {
         var (id, base) = newTwoWayAuction();
-        bidder1.doBid(1, 100 * T2, 60 * T1);
+        bidder1.doBid(base, 100 * T2, 60 * T1);
         assertEq(manager.isReversed(id), false);
     }
     function testBaseSplitOverTargetReversal() {
         var (id, base) = newTwoWayAuction();
-        bidder1.doBid(1, 110 * T2, 60 * T1);
+        bidder1.doBid(base, 110 * T2, 60 * T1);
         assertEq(manager.isReversed(id), true);
     }
     function testBaseSplitOverTargetRefundsDifference() {
         var (id, base) = newTwoWayAuction();
         var t2_balance_before = t2.balanceOf(bidder1);
-        bidder1.doBid(1, 120 * T2, 60 * T1);
+        bidder1.doBid(base, 120 * T2, 60 * T1);
         var t2_balance_after = t2.balanceOf(bidder1);
 
         var balance_diff = t2_balance_before - t2_balance_after;
@@ -189,7 +189,7 @@ contract TwoWayTest is Test, EventfulAuction, EventfulManager {
     }
     function testBaseSplitOverTargetSetsReverseBidder() {
         var (id, base) = newTwoWayAuction();
-        var (nid, sid) = bidder1.doBid(1, 120 * T2, 50 * T1);
+        var (nid, sid) = bidder1.doBid(base, 120 * T2, 50 * T1);
 
         var (auction_id, last_bidder,
              buy_amount, sell_amount) = manager.getAuctionlet(sid);
@@ -198,7 +198,7 @@ contract TwoWayTest is Test, EventfulAuction, EventfulManager {
     }
     function testBaseSplitOverTargetSetsReverseBuyAmount() {
         var (id, base) = newTwoWayAuction();
-        var (nid, sid) = bidder1.doBid(1, 120 * T2, 50 * T1);
+        var (nid, sid) = bidder1.doBid(base, 120 * T2, 50 * T1);
 
         var (auction_id, last_bidder,
              buy_amount, sell_amount) = manager.getAuctionlet(sid);
@@ -207,7 +207,7 @@ contract TwoWayTest is Test, EventfulAuction, EventfulManager {
     }
     function testBaseSplitOverTargetSetsReverseBid() {
         var (id, base) = newTwoWayAuction();
-        var (nid, sid) = bidder1.doBid(1, 120 * T2, 50 * T1);
+        var (nid, sid) = bidder1.doBid(base, 120 * T2, 50 * T1);
 
         var (auction_id, last_bidder,
              buy_amount, sell_amount) = manager.getAuctionlet(sid);

--- a/contracts/twoway_test.sol
+++ b/contracts/twoway_test.sol
@@ -88,16 +88,16 @@ contract TwoWayTest is Test, EventfulAuction, EventfulManager {
         t2.approve(manager, 1000 * T2);
     }
     function newTwoWayAuction() returns (uint, uint) {
-        return manager.newTwoWayAuction({beneficiary: seller,
-                                         selling: t1,
-                                         buying: t2,
-                                         sell_amount: 100 * T1,
-                                         start_bid: 10 * T2,
-                                         min_increase: 1 * T2,
-                                         min_decrease: 1 * T1,
-                                         duration: 1 years,
-                                         collection_limit: 100 * T2,
-                                        });
+        return manager.newTwoWayAuction( seller    // beneficiary
+                                       , t1        // selling
+                                       , t2        // buying
+                                       , 100 * T1  // sell_amount
+                                       , 10 * T2   // start_bid
+                                       , 1 * T2    // min_increase
+                                       , 1 * T1    // min_decrease
+                                       , 1 years   // duration
+                                       , 100 * T2  // collection_limit
+                                       );
     }
     function testReversalEvent() {
         var (id, base) = newTwoWayAuction();

--- a/contracts/twoway_test.sol
+++ b/contracts/twoway_test.sol
@@ -113,13 +113,13 @@ contract TwoWayTest is Test, EventfulAuction, EventfulManager {
         assertEq(manager.getCollectMax(id), 100 * T2);
     }
     function testBidEqualTargetNoReversal() {
-        // bids at or over the target should cause the auction to reverse
+        // bids at the target should not cause the auction to reverse
         var (id, base) = newTwoWayAuction();
         bidder1.doBid(1, 100 * T2);
         assertEq(manager.isReversed(id), false);
     }
     function testBidOverTargetReversal() {
-        // bids at or over the target should cause the auction to reverse
+        // bids over the target should cause the auction to reverse
         var (id, base) = newTwoWayAuction();
         bidder1.doBid(1, 101 * T2);
         assertEq(manager.isReversed(id), true);

--- a/contracts/twoway_test.sol
+++ b/contracts/twoway_test.sol
@@ -299,7 +299,6 @@ contract TwoWayMultipleBeneficiariesTest is Test, EventfulAuction, EventfulManag
                                                    , 1 * T2
                                                    , 1 * T1
                                                    , 1 years
-                                                   , 100 * T2
                                                    );
 
         var (beneficiary, selling, buying,
@@ -311,5 +310,34 @@ contract TwoWayMultipleBeneficiariesTest is Test, EventfulAuction, EventfulManag
          sell_amount, start_bid, min_increase, expiration) = manager.getAuction(id2);
 
         assertEq(beneficiary, beneficiary1);
+    }
+    function testSumPayoutsSetsCollectionLimit() {
+        address[] memory beneficiaries = new address[](2);
+        beneficiaries[0] = beneficiary1;
+        beneficiaries[1] = beneficiary2;
+
+        uint[] memory payouts = new uint[](2);
+        payouts[0] = 60 * T2;
+        payouts[1] = 40 * T2;
+
+        var (id, base) = manager.newTwoWayAuction( beneficiaries
+                                                 , payouts
+                                                 , t1
+                                                 , t2
+                                                 , 100 * T1
+                                                 , 10 * T2
+                                                 , 1 * T2
+                                                 , 1 * T1
+                                                 , 1 years
+                                                 );
+
+        bidder1.doBid(base, 101 * T2);
+
+        expectEventsExact(manager);
+        NewAuction(id, base);
+        AuctionReversal(id);
+        Bid(base);
+
+        assertEq(manager.isReversed(id), true);
     }
 }


### PR DESCRIPTION
Implementing #1.

Implementation plan:
- [x] replace `Auction` field `address beneficiary` with `address[] beneficiaries`
- [x] add `Auction` field `uint[] payouts`
- [x] override auction init to accept old behaviour (single beneficiary) or new arrays
- [x] assert `payouts.length == beneficiaries.length`
- [x] assert `sum(payouts) == collection_limit` (i.e. only implement in forward part of auction for now)
- [x] assert `payouts[0] >= start_bid`
- [x] modify `settleExcessBuy` to partition new bid excess among beneficiaries
- [x] ~~think about UX of specifying all payouts. Should there be a way to infer the remaining payout, to make the forward auction easier to initialise? (The collection limit is 'infinite' == 2 *\* 256 - 1, so this has to be reasoned with).~~ (addressed by #2)
- [x] create initialiser for two-way auction
- [x] remove collection limit arg in case of two-way with payouts array
- [x] more multi beneficiary two-way tests
