### PR TITLE
Independent auctionlet expiry

### DIFF
--- a/contracts/auction_manager.sol
+++ b/contracts/auction_manager.sol
@@ -161,18 +161,6 @@ contract AuctionUser is EventfulAuction
         _assertClaimable(auctionlet_id);
         _doClaim(auctionlet_id);
     }
-    // Starting an auction takes funds from the beneficiary to keep in
-    // escrow. If there are any funds remaining after expiry, e.g. if
-    // there were no bids or if only a portion of the lot was bid for,
-    // the seller can reclaim them.
-    function reclaim(uint auction_id) {
-        var A = _auctions[auction_id];
-        var expired = A.expiration <= getTime();
-        assert(expired);
-
-        settleReclaim(A);
-        A.unsold = 0;
-    }
     // Check whether an auctionlet is eligible for bidding on
     function _assertBiddable(uint auctionlet_id, uint bid_how_much) internal {
         var a = _auctionlets[auctionlet_id];

--- a/contracts/tests/auction_manager.sol
+++ b/contracts/tests/auction_manager.sol
@@ -39,7 +39,7 @@ contract AuctionManagerTest is AuctionTest, EventfulAuction, EventfulManager {
         assertEq(id, 1);
 
         var (beneficiary, selling, buying,
-             sell_amount, start_bid, min_increase, expiration) = manager.getAuction(id);
+             sell_amount, start_bid, min_increase, duration) = manager.getAuction(id);
 
         assertEq(beneficiary, seller);
         assertTrue(selling == t1);
@@ -47,7 +47,7 @@ contract AuctionManagerTest is AuctionTest, EventfulAuction, EventfulManager {
         assertEq(sell_amount, 100 * T1);
         assertEq(start_bid, 10 * T2);
         assertEq(min_increase, 1 * T2);
-        assertEq(expiration, manager.getTime() + 1 years);
+        assertEq(duration, 1 years);
     }
     function testNewAuctionTransfersToManager() {
         var balance_before = t1.balanceOf(manager);
@@ -132,6 +132,15 @@ contract AuctionManagerTest is AuctionTest, EventfulAuction, EventfulManager {
 
         bidder2.doBid(base, 12 * T2);
     }
+    function testBaseDoesNotExpire() {
+        var (id, base) = newAuction();
+
+        // push past the base auction duration
+        manager.addTime(2 years);
+
+        // this should succeed as there are no real bidders
+        bidder1.doBid(base, 11 * T2);
+    }
     function testBidTransfersBenefactor() {
         var (id, base) = newAuction();
 
@@ -196,7 +205,7 @@ contract AuctionManagerTest is AuctionTest, EventfulAuction, EventfulManager {
         assertEq(t2_balance_before - t2.balanceOf(this), 100 * T2);
 
         var (beneficiary, selling, buying,
-             sell_amount, start_bid, min_increase, expiration) = manager.getAuction(id2);
+             sell_amount, start_bid, min_increase, duration) = manager.getAuction(id2);
 
         assertEq(beneficiary, seller);
         assertTrue(selling == t2);
@@ -204,7 +213,7 @@ contract AuctionManagerTest is AuctionTest, EventfulAuction, EventfulManager {
         assertEq(sell_amount, 100 * T2);
         assertEq(start_bid, 10 * T1);
         assertEq(min_increase, 1 * T1);
-        assertEq(expiration, manager.getTime() + 1 years);
+        assertEq(duration, 1 years);
     }
     function testMultipleAuctionsBidTransferToBenefactor() {
         var (id1, base1) = newAuction();

--- a/contracts/tests/auction_manager.sol
+++ b/contracts/tests/auction_manager.sol
@@ -248,24 +248,6 @@ contract AuctionManagerTest is AuctionTest, EventfulAuction, EventfulManager {
         bidder1.doClaim(1);
         bidder1.doClaim(1);
     }
-    function testReclaimAfterExpiry() {
-        // the seller should be able to reclaim any unbid on
-        // sell token after the auction has expired.
-        var (id, base) = newAuction();
-
-        // force expiry
-        manager.addTime(2 years);
-
-        var balance_before = t1.balanceOf(this);
-        manager.reclaim(id);
-        var balance_after = t1.balanceOf(this);
-
-        assertEq(balance_after - balance_before, 100 * T1);
-    }
-    function testFailReclaimBeforeExpiry() {
-        var (id, base) = newAuction();
-        seller.doReclaim(id);
-    }
     function testBidTransfersToDistinctBeneficiary() {
         var (id, base) = manager.newAuction(bidder2, t1, t2, 100 * T1, 0 * T2, 1 * T2, 1 years);
 
@@ -274,20 +256,6 @@ contract AuctionManagerTest is AuctionTest, EventfulAuction, EventfulManager {
         var balance_after = t2.balanceOf(bidder2);
 
         assertEq(balance_after - balance_before, 10 * T2);
-    }
-    function testReclaimOnlyOnce() {
-        var (id1, base1) = newAuction();
-        var (id2, base2) = newAuction();
-
-        // force expiry
-        manager.addTime(2 years);
-
-        manager.reclaim(id1);
-        var balance_before = t1.balanceOf(this);
-        manager.reclaim(id1);
-        var balance_after = t1.balanceOf(this);
-
-        assertEq(balance_after, balance_before);
     }
 }
 

--- a/contracts/tests/auction_manager.sol
+++ b/contracts/tests/auction_manager.sol
@@ -243,10 +243,13 @@ contract AuctionManagerTest is AuctionTest, EventfulAuction, EventfulManager {
         bidder1.doBid(base1, 11 * T2);
         bidder2.doBid(base2, 11 * T2);
 
+        // force expiry
+        manager.addTime(2 years);
+
         // now attempt to claim the proceedings from the first
         // auctionlet twice
-        bidder1.doClaim(1);
-        bidder1.doClaim(1);
+        bidder1.doClaim(base1);
+        bidder1.doClaim(base1);
     }
     function testBidTransfersToDistinctBeneficiary() {
         var (id, base) = manager.newAuction(bidder2, t1, t2, 100 * T1, 0 * T2, 1 * T2, 1 years);

--- a/contracts/tests/auction_manager.sol
+++ b/contracts/tests/auction_manager.sol
@@ -128,7 +128,7 @@ contract AuctionManagerTest is AuctionTest, EventfulAuction, EventfulManager {
         bidder1.doBid(base, 11 * T2);
 
         // force expiry
-        manager.setTime(manager.getTime() + 2 years);
+        manager.addTime(2 years);
 
         bidder2.doBid(base, 12 * T2);
     }
@@ -149,7 +149,7 @@ contract AuctionManagerTest is AuctionTest, EventfulAuction, EventfulManager {
         bidder1.doBid(base, 11 * T2);
 
         // force expiry
-        manager.setTime(manager.getTime() + 2 years);
+        manager.addTime(2 years);
 
         // n.b. anyone can force claim, not just the bidder
         manager.claim(1);
@@ -254,7 +254,7 @@ contract AuctionManagerTest is AuctionTest, EventfulAuction, EventfulManager {
         var (id, base) = newAuction();
 
         // force expiry
-        manager.setTime(manager.getTime() + 2 years);
+        manager.addTime(2 years);
 
         var balance_before = t1.balanceOf(this);
         manager.reclaim(id);
@@ -280,7 +280,7 @@ contract AuctionManagerTest is AuctionTest, EventfulAuction, EventfulManager {
         var (id2, base2) = newAuction();
 
         // force expiry
-        manager.setTime(manager.getTime() + 2 years);
+        manager.addTime(2 years);
 
         manager.reclaim(id1);
         var balance_before = t1.balanceOf(this);

--- a/contracts/tests/base.sol
+++ b/contracts/tests/base.sol
@@ -11,6 +11,9 @@ contract TestableManager is SplittingAuctionManager {
     function setTime(uint timestamp) {
         debug_timestamp = timestamp;
     }
+    function addTime(uint time) {
+        setTime(getTime() + time);
+    }
     function getCollectMax(uint auction_id) returns (uint) {
         return _auctions[auction_id].collection_limit;
     }

--- a/contracts/tests/base.sol
+++ b/contracts/tests/base.sol
@@ -20,12 +20,17 @@ contract TestableManager is SplittingAuctionManager {
     function isReversed(uint auction_id) returns (bool) {
         return _auctions[auction_id].reversed;
     }
+    function isExpired(uint auctionlet_id) returns (bool) {
+        var a = _auctionlets[auctionlet_id];
+        var A = _auctions[a.auction_id];
+        return (getTime() - a.last_bid_time) > A.duration;
+    }
     function getAuction(uint id) constant
         returns (address, ERC20, ERC20, uint, uint, uint, uint)
     {
         Auction a = _auctions[id];
         return (a.beneficiaries[0], a.selling, a.buying,
-                a.sell_amount, a.start_bid, a.min_increase, a.expiration);
+                a.sell_amount, a.start_bid, a.min_increase, a.duration);
     }
     function getAuctionlet(uint id) constant
         returns (uint, address, uint, uint)

--- a/contracts/tests/base.sol
+++ b/contracts/tests/base.sol
@@ -17,14 +17,6 @@ contract TestableManager is SplittingAuctionManager {
     function getCollectMax(uint auction_id) returns (uint) {
         return _auctions[auction_id].collection_limit;
     }
-    function isReversed(uint auction_id) returns (bool) {
-        return _auctions[auction_id].reversed;
-    }
-    function isExpired(uint auctionlet_id) returns (bool) {
-        var a = _auctionlets[auctionlet_id];
-        var A = _auctions[a.auction_id];
-        return (getTime() - a.last_bid_time) > A.duration;
-    }
     function getAuction(uint id) constant
         returns (address, ERC20, ERC20, uint, uint, uint, uint)
     {

--- a/contracts/tests/base.sol
+++ b/contracts/tests/base.sol
@@ -56,9 +56,6 @@ contract AuctionTester is Tester {
     function doClaim(uint id) {
         return manager.claim(id);
     }
-    function doReclaim(uint id) {
-        return manager.reclaim(id);
-    }
 }
 
 contract AuctionTest is Test {

--- a/contracts/tests/reverse.sol
+++ b/contracts/tests/reverse.sol
@@ -124,7 +124,7 @@ contract ReverseTest is AuctionTest {
         bidder1.doBid(1, 85 * T1);
 
         // force expiry
-        manager.setTime(manager.getTime() + 2 years);
+        manager.addTime(2 years);
 
         var t1_balance_before = t1.balanceOf(bidder1);
         bidder1.doClaim(1);
@@ -139,7 +139,7 @@ contract ReverseTest is AuctionTest {
         var (id, base) = newReverseAuction();
 
         // force expiry
-        manager.setTime(manager.getTime() + 2 years);
+        manager.addTime(2 years);
 
         var balance_before = t1.balanceOf(this);
         manager.reclaim(id);
@@ -155,7 +155,7 @@ contract ReverseTest is AuctionTest {
         bidder1.doBid(base, 50 * T1);
 
         // force expiry
-        manager.setTime(manager.getTime() + 2 years);
+        manager.addTime(2 years);
 
         var balance_before = t1.balanceOf(this);
         manager.reclaim(id);

--- a/contracts/tests/reverse.sol
+++ b/contracts/tests/reverse.sol
@@ -133,34 +133,4 @@ contract ReverseTest is AuctionTest {
 
         assertEq(t1_balance_diff, 85 * T1);
     }
-    function testCreatorReclaimAfterExpiry() {
-        // the seller should be able to reclaim any unbid on
-        // sell token after the auction has expired.
-        var (id, base) = newReverseAuction();
-
-        // force expiry
-        manager.addTime(2 years);
-
-        var balance_before = t1.balanceOf(this);
-        manager.reclaim(id);
-        var balance_after = t1.balanceOf(this);
-
-        assertEq(balance_after - balance_before, 100 * T1);
-    }
-    function testCreatorReclaimAfterBid() {
-        // if there has already been a bid (on the full lot), the
-        // creator should not receive any more sell token on reclaim
-        var (id, base) = newReverseAuction();
-
-        bidder1.doBid(base, 50 * T1);
-
-        // force expiry
-        manager.addTime(2 years);
-
-        var balance_before = t1.balanceOf(this);
-        manager.reclaim(id);
-        var balance_after = t1.balanceOf(this);
-
-        assertEq(balance_after, balance_after);
-    }
 }

--- a/contracts/tests/reverse_splitting.sol
+++ b/contracts/tests/reverse_splitting.sol
@@ -176,7 +176,7 @@ contract ReverseSplittingTest is AuctionTest {
         bidder1.doBid(base, 90 * T1);
 
         // force expiry
-        manager.setTime(manager.getTime() + 2 years);
+        manager.addTime(2 years);
 
         bidder2.doBid(base, 40 * T1, 4 * T2);
     }
@@ -209,7 +209,7 @@ contract ReverseSplittingTest is AuctionTest {
         bidder1.doBid(base, 50 * T1, 3 * T2);
 
         // force expiry
-        manager.setTime(manager.getTime() + 2 years);
+        manager.addTime(+ 2 years);
 
         var balance_before = t1.balanceOf(this);
         manager.reclaim(id);
@@ -227,7 +227,7 @@ contract ReverseSplittingTest is AuctionTest {
         bidder2.doBid(sid, 20 * T1, 2 * T2);
 
         // force expiry
-        manager.setTime(manager.getTime() + 2 years);
+        manager.addTime(2 years);
 
         var balance_before = t1.balanceOf(this);
         manager.reclaim(id);

--- a/contracts/tests/reverse_splitting.sol
+++ b/contracts/tests/reverse_splitting.sol
@@ -203,39 +203,4 @@ contract ReverseSplittingTest is AuctionTest {
         // 20 + 80 * (4 / 5) - 40 = 44
         assertEq(balance_after - balance_before, 44 * T1);
     }
-    function testCreatorReclaimAfterBaseSplit() {
-        var (id, base) = newReverseAuction();
-
-        bidder1.doBid(base, 50 * T1, 3 * T2);
-
-        // force expiry
-        manager.addTime(+ 2 years);
-
-        var balance_before = t1.balanceOf(this);
-        manager.reclaim(id);
-        var balance_after = t1.balanceOf(this);
-
-        // check that the unsold sell tokens are sent back
-        // to the creator.
-        // 100 * (5 - 3) / 5 = 40
-        assertEq(balance_after - balance_before, 40 * T1);
-    }
-    function testCreatorReclaimAfterSplitBaseSplit() {
-        var (id, base) = newReverseAuction();
-
-        var (nid, sid) = bidder1.doBid(base, 50 * T1, 3 * T2);
-        bidder2.doBid(sid, 20 * T1, 2 * T2);
-
-        // force expiry
-        manager.addTime(2 years);
-
-        var balance_before = t1.balanceOf(this);
-        manager.reclaim(id);
-        var balance_after = t1.balanceOf(this);
-
-        // There should still be the same number of tokens available for
-        // reclaim as the second split is a sub-split of the first.
-        // 100 * (5 - 3) / 5 = 40
-        assertEq(balance_after - balance_before, 40 * T1);
-    }
 }

--- a/contracts/tests/splitting_auction.sol
+++ b/contracts/tests/splitting_auction.sol
@@ -283,7 +283,7 @@ contract ForwardSplittingTest is AuctionTest
         bidder1.doBid(base, 11 * T2);
 
         // force expiry
-        manager.setTime(manager.getTime() + 2 years);
+        manager.addTime(2 years);
 
         bidder2.doBid(base, 10 * T2, 50 * T1);
     }
@@ -338,7 +338,7 @@ contract ForwardSplittingTest is AuctionTest
 
         bidder1.doBid(base, 20 * T2, 50 * T1);
         // force expiry
-        manager.setTime(manager.getTime() + 2 years);
+        manager.addTime(2 years);
 
         var balance_before = t1.balanceOf(this);
         manager.reclaim(id);
@@ -352,7 +352,7 @@ contract ForwardSplittingTest is AuctionTest
         var (nid, sid) = bidder1.doBid(base, 20 * T2, 50 * T1);
         bidder2.doBid(sid, 20 * T2, 40 * T1);
         // force expiry
-        manager.setTime(manager.getTime() + 2 years);
+        manager.addTime(2 years);
 
         var balance_before = t1.balanceOf(this);
         manager.reclaim(id);

--- a/contracts/tests/splitting_auction.sol
+++ b/contracts/tests/splitting_auction.sol
@@ -333,4 +333,38 @@ contract ForwardSplittingTest is AuctionTest
         var (nid, sid) = bidder2.doBid(base, 12 * T2, 60 * T1);
         bidder1.doBid(base, 20 * T2, 60 * T1);
     }
+    function testBaseDoesNotExpire() {
+        var (id, base) = newAuction();
+
+        var (nid, sid) = bidder1.doBid(base, 7 * T2, 60 * T1);
+
+        // push past the base auction duration
+        manager.addTime(2 years);
+
+        // this should succeed as there are no real bidders
+        bidder1.doBid(nid, 11 * T2);
+    }
+    function testFailSplitExpires() {
+        var (id, base) = newAuction();
+
+        var (nid, sid) = bidder1.doBid(base, 7 * T2, 60 * T1);
+
+        // push past the base auction duration
+        manager.addTime(2 years);
+
+        // this should succeed as there are no real bidders
+        bidder1.doBid(sid, 11 * T2);
+    }
+    function testIndependentExpirations() {
+        var (id, base) = newAuction();
+
+        var (nid, sid) = bidder1.doBid(base, 7 * T2, 60 * T1);
+
+        manager.addTime(200 days);
+        bidder1.doBid(nid, 10 * T2);
+        manager.addTime(200 days);
+
+        assertTrue(manager.isExpired(sid));
+        assertFalse(manager.isExpired(nid));
+    }
 }

--- a/contracts/tests/splitting_auction.sol
+++ b/contracts/tests/splitting_auction.sol
@@ -333,33 +333,4 @@ contract ForwardSplittingTest is AuctionTest
         var (nid, sid) = bidder2.doBid(base, 12 * T2, 60 * T1);
         bidder1.doBid(base, 20 * T2, 60 * T1);
     }
-    function testReclaimAfterBaseSplit() {
-        var (id, base) = newAuction();
-
-        bidder1.doBid(base, 20 * T2, 50 * T1);
-        // force expiry
-        manager.addTime(2 years);
-
-        var balance_before = t1.balanceOf(this);
-        manager.reclaim(id);
-        var balance_after = t1.balanceOf(this);
-
-        assertEq(balance_after - balance_before, 50 * T1);
-    }
-    function testReclaimAfterSplitBaseSplit() {
-        var (id, base) = newAuction();
-
-        var (nid, sid) = bidder1.doBid(base, 20 * T2, 50 * T1);
-        bidder2.doBid(sid, 20 * T2, 40 * T1);
-        // force expiry
-        manager.addTime(2 years);
-
-        var balance_before = t1.balanceOf(this);
-        manager.reclaim(id);
-        var balance_after = t1.balanceOf(this);
-
-        // reclaimable balance should be the same as after
-        // just the base split
-        assertEq(balance_after - balance_before, 50 * T1);
-    }
 }


### PR DESCRIPTION
Builds on #9 and #10.

Fixes #6.

Give auctionlets independent expiry (rather than global auction expiry). This makes the auction truly 'continuous'.

Features:
- creator can no longer `reclaim` (was needed for when full lot not bid on and auction expired)
- unbid auctionlets (e.g. leftover from a split) never expire - can always be bid on
- bid on auctionlets will 'expire' when they have not been bid on for the 'duration', which is given in the auction initialiser.
