### PR TITLE
Configure sell token refund address

### DIFF
--- a/contracts/auction_manager.sol
+++ b/contracts/auction_manager.sol
@@ -319,10 +319,7 @@ contract AuctionManager is AuctionUser, EventfulManager {
                         )
         returns (uint auction_id, uint base_id)
     {
-        address[] memory beneficiaries = new address[](1);
-        beneficiaries[0] = beneficiary;
-        uint[] memory payouts = new uint[](1);
-        payouts[0] = INFINITY;
+        var (beneficiaries, payouts) = makeSinglePayout(beneficiary, INFINITY);
 
         (auction_id, base_id) = _newTwoWayAuction({creator: msg.sender,
                                                    beneficiaries: beneficiaries,
@@ -374,10 +371,7 @@ contract AuctionManager is AuctionUser, EventfulManager {
                               )
         returns (uint auction_id, uint base_id)
     {
-        address[] memory beneficiaries = new address[](1);
-        beneficiaries[0] = beneficiary;
-        uint[] memory payouts = new uint[](1);
-        payouts[0] = 0;
+        var (beneficiaries, payouts) = makeSinglePayout(beneficiary, 0);
 
         // the Reverse Auction is the limit of the two way auction
         // where the maximum collected buying token is zero.
@@ -408,10 +402,7 @@ contract AuctionManager is AuctionUser, EventfulManager {
                              )
         returns (uint, uint)
     {
-        address[] memory beneficiaries = new address[](1);
-        beneficiaries[0] = beneficiary;
-        uint[] memory payouts = new uint[](1);
-        payouts[0] = collection_limit;
+        var (beneficiaries, payouts) = makeSinglePayout(beneficiary, collection_limit);
 
         return _newTwoWayAuction({creator: msg.sender,
                                   beneficiaries: beneficiaries,
@@ -458,6 +449,18 @@ contract AuctionManager is AuctionUser, EventfulManager {
         assert(A.beneficiaries.length == A.payouts.length);
         if (!A.reversed) assert(A.payouts[0] >= A.start_bid);
         assert(sum(A.payouts) == A.collection_limit);
+    }
+    function makeSinglePayout(address beneficiary, uint collection_limit)
+        internal
+        returns (address[], uint[])
+    {
+        address[] memory beneficiaries = new address[](1);
+        uint[] memory payouts = new uint[](1);
+
+        beneficiaries[0] = beneficiary;
+        payouts[0] = collection_limit;
+
+        return (beneficiaries, payouts);
     }
     function _newTwoWayAuction( address creator
                               , address[] beneficiaries

--- a/contracts/auction_manager.sol
+++ b/contracts/auction_manager.sol
@@ -136,6 +136,13 @@ contract AuctionDatabase is AuctionTypes, TimeUser {
         var A = _auctions[a.auction_id];
         expired = (getTime() - a.last_bid_time) > A.duration;
     }
+    function getRefundAddress(uint auction_id) returns (address) {
+        return _auctions[auction_id].refund;
+    }
+    function setRefundAddress(uint auction_id, address refund) {
+        var A = _auctions[auction_id];
+        A.refund = refund;
+    }
 }
 
 contract AuctionUser is EventfulAuction

--- a/contracts/auction_manager.sol
+++ b/contracts/auction_manager.sol
@@ -42,6 +42,7 @@ contract AuctionTypes {
         address creator;
         address[] beneficiaries;
         uint[] payouts;
+        address refund;
         ERC20 selling;
         ERC20 buying;
         uint start_bid;
@@ -97,7 +98,7 @@ contract TransferUser is Assertive, AuctionTypes, MathUser {
         }
     }
     function settleExcessSell(Auction A, uint excess_sell) internal {
-        assert(A.selling.transfer(A.beneficiaries[0], excess_sell));
+        assert(A.selling.transfer(A.refund, excess_sell));
     }
     function settleBidderClaim(Auction A, Auctionlet a) internal {
         assert(A.selling.transfer(a.last_bidder, a.sell_amount));
@@ -482,6 +483,7 @@ contract AuctionManager is AuctionUser, EventfulManager {
         A.creator = creator;
         A.beneficiaries = beneficiaries;
         A.payouts = payouts;
+        A.refund = beneficiaries[0];
         A.selling = selling;
         A.buying = buying;
         A.sell_amount = sell_amount;

--- a/contracts/auction_manager.sol
+++ b/contracts/auction_manager.sol
@@ -139,9 +139,16 @@ contract AuctionDatabase is AuctionTypes, TimeUser {
     function getRefundAddress(uint auction_id) returns (address) {
         return _auctions[auction_id].refund;
     }
-    function setRefundAddress(uint auction_id, address refund) {
+    function setRefundAddress(uint auction_id, address refund)
+        only_creator(auction_id)
+    {
         var A = _auctions[auction_id];
         A.refund = refund;
+    }
+    modifier only_creator(uint auction_id) {
+        if (msg.sender != _auctions[auction_id].creator)
+            throw;
+        _
     }
 }
 

--- a/contracts/tests/auction_manager.sol
+++ b/contracts/tests/auction_manager.sol
@@ -272,16 +272,6 @@ contract AuctionManagerTest is AuctionTest, EventfulAuction, EventfulManager {
 }
 
 contract MultipleBeneficiariesTest is AuctionTest, EventfulAuction, EventfulManager {
-    AuctionTester beneficiary1;
-    AuctionTester beneficiary2;
-
-    uint constant INFINITY = uint(-1);
-
-    function setUp() {
-        super.setUp();
-        beneficiary1 = new AuctionTester();
-        beneficiary2 = new AuctionTester();
-    }
     function testNewAuction() {
         address[] memory beneficiaries = new address[](1);
         beneficiaries[0] = beneficiary1;

--- a/contracts/tests/base.sol
+++ b/contracts/tests/base.sol
@@ -60,6 +60,8 @@ contract AuctionTest is Test {
     AuctionTester seller;
     AuctionTester bidder1;
     AuctionTester bidder2;
+    AuctionTester beneficiary1;
+    AuctionTester beneficiary2;
 
     ERC20 t1;
     ERC20 t2;
@@ -67,6 +69,8 @@ contract AuctionTest is Test {
     // use prime numbers to avoid coincidental collisions
     uint constant T1 = 5 ** 12;
     uint constant T2 = 7 ** 10;
+
+    uint constant INFINITY = uint(-1);
 
     function setUp() {
         manager = new TestableManager();
@@ -99,5 +103,8 @@ contract AuctionTest is Test {
         t2.transfer(this, 1000 * T2);
         t1.approve(manager, 1000 * T1);
         t2.approve(manager, 1000 * T2);
+
+        beneficiary1 = new AuctionTester();
+        beneficiary2 = new AuctionTester();
     }
 }

--- a/contracts/tests/db.sol
+++ b/contracts/tests/db.sol
@@ -1,0 +1,43 @@
+import 'tests/base.sol';
+
+import 'auction_manager.sol';
+
+contract DBTester is AuctionTester {
+    function doSetRefundAddress(uint id, address refund) {
+        manager.setRefundAddress(id, refund);
+    }
+}
+
+contract AuctionDBTest is AuctionTest, EventfulAuction, EventfulManager {
+    DBTester tester;
+
+    function newAuction() returns (uint, uint) {
+        return manager.newAuction( seller    // beneficiary
+                                 , t1        // selling
+                                 , t2        // buying
+                                 , 100 * T1  // sell_amount
+                                 , 10 * T2   // start_bid
+                                 , 1 * T2    // min_increase
+                                 , 1 years   // duration
+                                 );
+    }
+    function testDefaultRefund() {
+        var (id, base) = newAuction();
+
+        assertEq(manager.getRefundAddress(id), seller);
+    }
+    function testSetRefund() {
+        var (id, base) = newAuction();
+
+        manager.setRefundAddress(id, beneficiary2);
+        assertEq(manager.getRefundAddress(id), beneficiary2);
+    }
+    function testFailSetRefundNotCreator() {
+        var (id, base) = newAuction();
+
+        tester = new DBTester();
+        tester.bindManager(manager);
+
+        tester.doSetRefundAddress(id, beneficiary2);
+    }
+}

--- a/contracts/tests/twoway.sol
+++ b/contracts/tests/twoway.sol
@@ -307,3 +307,66 @@ contract TwoWayMultipleBeneficiariesTest is AuctionTest
         assertEq(balance_after - balance_before, 40 * T2);
     }
 }
+
+// two-way auction with given refund address
+contract TwoWayRefundTest is AuctionTest, EventfulAuction, EventfulManager {
+    function newTwoWayAuction() returns (uint auction_id, uint base_id) {
+        (auction_id, base_id) = manager.newTwoWayAuction( seller        // beneficiary
+                                                        , t1            // selling
+                                                        , t2            // buying
+                                                        , 100 * T1      // sell_amount
+                                                        , 10 * T2       // start_bid
+                                                        , 1 * T2        // min_increase
+                                                        , 1 * T1        // min_decrease
+                                                        , 1 years       // duration
+                                                        , 100 * T2      // collection_limit
+                                                        );
+        manager.setRefundAddress(auction_id, beneficiary1);
+    }
+    function testNewTwoWayAuction() {
+        var (id, base) = newTwoWayAuction();
+        assertEq(manager.getRefundAddress(id), beneficiary1);
+    }
+    function testBidTransfersRefund() {
+        // successive bids in the reverse part of the auction should
+        // refund the `refund` address
+        var (id, base) = newTwoWayAuction();
+
+        bidder1.doBid(base, 101 * T2);
+        bidder1.doBid(base, 90 * T1);
+
+        var balance_before = t1.balanceOf(beneficiary1);
+        bidder2.doBid(base, 80 * T1);
+        var balance_after = t1.balanceOf(beneficiary1);
+
+        assertEq(balance_after - balance_before, 10 * T1);
+    }
+    function testBidNoTransferToCreator() {
+        // successive bids in the reverse part of the auction should
+        // send nothing to the creator
+        var (id, base) = newTwoWayAuction();
+
+        bidder1.doBid(base, 101 * T2);
+        bidder1.doBid(base, 90 * T1);
+
+        var balance_before = t1.balanceOf(this);
+        bidder2.doBid(base, 80 * T1);
+        var balance_after = t1.balanceOf(this);
+
+        assertEq(balance_after, balance_before);
+    }
+    function testBidNoTransferToBeneficiary() {
+        // successive bids in the reverse part of the auction should
+        // send nothing to the creator
+        var (id, base) = newTwoWayAuction();
+
+        bidder1.doBid(base, 101 * T2);
+        bidder1.doBid(base, 90 * T1);
+
+        var balance_before = t1.balanceOf(seller);
+        bidder2.doBid(base, 80 * T1);
+        var balance_after = t1.balanceOf(seller);
+
+        assertEq(balance_after, balance_before);
+    }
+}

--- a/contracts/tests/twoway.sol
+++ b/contracts/tests/twoway.sol
@@ -143,16 +143,6 @@ contract TwoWayMultipleBeneficiariesTest is AuctionTest
                                           , EventfulAuction
                                           , EventfulManager
 {
-    AuctionTester beneficiary1;
-    AuctionTester beneficiary2;
-
-    uint constant INFINITY = uint(-1);
-
-    function setUp() {
-        super.setUp();
-        beneficiary1 = new AuctionTester();
-        beneficiary2 = new AuctionTester();
-    }
     function testNewAuction() {
         address[] memory beneficiaries = new address[](1);
         beneficiaries[0] = beneficiary1;


### PR DESCRIPTION
This PR allows the auction creator to configure the address that excess sell token is refunded to. This applies to the reverse auction and the reverse part of the two-way auction. Fixes #5.

The default is to refund the excess sell token to the _first beneficiary_. This can be changed by calling `setRefundAddress` after auction creation - only the auction creator (the caller of `newAuction`) can do this.

Example:

```
var (auction_id, base_id) = manager.newTwoWayAuction( ...init params... );
manager.setRefundAddress(auction_id, some_different_address);
```

I initially tried to set the refund address in the newAuction initialiser but couldn't get around stack depth problems.
