### PR TITLE
Make change on last bid relative (not absolute)

### DIFF
--- a/contracts/auction_manager.sol
+++ b/contracts/auction_manager.sol
@@ -196,10 +196,10 @@ contract AuctionUser is EventfulAuction
 
         if (A.reversed) {
             // check if reverse biddable
-            assert(bid_how_much <= (a.sell_amount - A.min_decrease));
+            assert(bid_how_much <= (a.sell_amount * (100 - A.min_decrease) / 100 ));
         } else {
             // check if forward biddable
-            assert(bid_how_much >= (a.buy_amount + A.min_increase));
+            assert(bid_how_much >= (a.buy_amount * (100 + A.min_increase) / 100 ));
         }
     }
     // Auctionlet bid logic, including transfers.

--- a/contracts/tests/auction_manager.sol
+++ b/contracts/tests/auction_manager.sol
@@ -81,10 +81,14 @@ contract AuctionManagerTest is AuctionTest, EventfulAuction, EventfulManager {
         var (id, base) = newAuction();
         bidder1.doBid(base, 9 * T2);
     }
-    function testFailBidUnderMinIncrease() {
+    function testFailFirstBidUnderMinIncrease() {
         var (id, base) = newAuction();
         bidder1.doBid(base, 10 * T2);
-        bidder2.doBid(base, 11 * T2);
+    }
+    function testFailSubsequentBidUnderMinIncrease() {
+        var (id, base) = newAuction();
+        bidder1.doBid(base, 12 * T2);
+        bidder2.doBid(base, 12 * T2);
     }
     function testBid() {
         var (id, base) = newAuction();

--- a/contracts/tests/auction_manager.sol
+++ b/contracts/tests/auction_manager.sol
@@ -14,7 +14,7 @@ contract AuctionManagerTest is AuctionTest, EventfulAuction, EventfulManager {
                                  , t2        // buying
                                  , 100 * T1  // sell_amount
                                  , 10 * T2   // start_bid
-                                 , 1 * T2    // min_increase
+                                 , 1         // min_increase (%)
                                  , 1 years   // duration
                                  );
     }
@@ -46,7 +46,7 @@ contract AuctionManagerTest is AuctionTest, EventfulAuction, EventfulManager {
         assertTrue(buying == t2);
         assertEq(sell_amount, 100 * T1);
         assertEq(start_bid, 10 * T2);
-        assertEq(min_increase, 1 * T2);
+        assertEq(min_increase, 1);
         assertEq(duration, 1 years);
     }
     function testNewAuctionTransfersToManager() {
@@ -80,15 +80,6 @@ contract AuctionManagerTest is AuctionTest, EventfulAuction, EventfulManager {
     function testFailBidUnderMinBid() {
         var (id, base) = newAuction();
         bidder1.doBid(base, 9 * T2);
-    }
-    function testFailFirstBidUnderMinIncrease() {
-        var (id, base) = newAuction();
-        bidder1.doBid(base, 10 * T2);
-    }
-    function testFailSubsequentBidUnderMinIncrease() {
-        var (id, base) = newAuction();
-        bidder1.doBid(base, 12 * T2);
-        bidder2.doBid(base, 12 * T2);
     }
     function testBid() {
         var (id, base) = newAuction();
@@ -200,7 +191,7 @@ contract AuctionManagerTest is AuctionTest, EventfulAuction, EventfulManager {
 
         var (id1, base1) = newAuction();
         // flip tokens around
-        var (id2, base2) = manager.newAuction(seller, t2, t1, 100 * T2, 10 * T1, 1 * T1, 1 years);
+        var (id2, base2) = manager.newAuction(seller, t2, t1, 100 * T2, 10 * T1, 1, 1 years);
 
         assertEq(id1, 1);
         assertEq(id2, 2);
@@ -216,7 +207,7 @@ contract AuctionManagerTest is AuctionTest, EventfulAuction, EventfulManager {
         assertTrue(buying == t1);
         assertEq(sell_amount, 100 * T2);
         assertEq(start_bid, 10 * T1);
-        assertEq(min_increase, 1 * T1);
+        assertEq(min_increase, 1);
         assertEq(duration, 1 years);
     }
     function testMultipleAuctionsBidTransferToBenefactor() {
@@ -265,13 +256,44 @@ contract AuctionManagerTest is AuctionTest, EventfulAuction, EventfulManager {
         bidder1.doClaim(base1);
     }
     function testBidTransfersToDistinctBeneficiary() {
-        var (id, base) = manager.newAuction(bidder2, t1, t2, 100 * T1, 0 * T2, 1 * T2, 1 years);
+        var (id, base) = manager.newAuction(bidder2, t1, t2, 100 * T1, 0 * T2, 1, 1 years);
 
         var balance_before = t2.balanceOf(bidder2);
         bidder1.doBid(base, 10 * T2);
         var balance_after = t2.balanceOf(bidder2);
 
         assertEq(balance_after - balance_before, 10 * T2);
+    }
+}
+
+contract MinBidIncreaseTest is AuctionTest, EventfulAuction, EventfulManager {
+    function newAuction() returns (uint, uint) {
+        return manager.newAuction( seller    // beneficiary
+                                 , t1        // selling
+                                 , t2        // buying
+                                 , 100 * T1  // sell_amount
+                                 , 10 * T2   // start_bid
+                                 , 20        // min_increase (%)
+                                 , 1 years   // duration
+                                 );
+    }
+    function testFailFirstBidEqualStartBid() {
+        var (id, base) = newAuction();
+        bidder1.doBid(base, 10 * T2);
+    }
+    function testFailSubsequentBidEqualLastBid() {
+        var (id, base) = newAuction();
+        bidder1.doBid(base, 13 * T2);
+        bidder2.doBid(base, 13 * T2);
+    }
+    function testFailFirstBidLowerThanMinIncrease() {
+        var (id, base) = newAuction();
+        bidder1.doBid(base, 11 * T2);
+    }
+    function testFailSubsequentBidLowerThanMinIncrease() {
+        var (id, base) = newAuction();
+        bidder1.doBid(base, 12 * T2);
+        bidder2.doBid(base, 13 * T2);
     }
 }
 
@@ -283,8 +305,8 @@ contract MultipleBeneficiariesTest is AuctionTest, EventfulAuction, EventfulMana
         uint[] memory payouts = new uint[](1);
         payouts[0] = INFINITY;
 
-        var (id1, base1) = manager.newAuction(beneficiary1, t1, t2, 100 * T1, 0 * T2, 1 * T2, 1 years);
-        var (id2, base2) = manager.newAuction(beneficiaries, payouts, t1, t2, 100 * T1, 0 * T2, 1 * T2, 1 years);
+        var (id1, base1) = manager.newAuction(beneficiary1, t1, t2, 100 * T1, 0 * T2, 1, 1 years);
+        var (id2, base2) = manager.newAuction(beneficiaries, payouts, t1, t2, 100 * T1, 0 * T2, 1, 1 years);
 
         var (beneficiary, selling, buying,
              sell_amount, start_bid, min_increase, expiration) = manager.getAuction(id1);
@@ -303,7 +325,7 @@ contract MultipleBeneficiariesTest is AuctionTest, EventfulAuction, EventfulMana
         uint[] memory payouts = new uint[](1);
         payouts[0] = INFINITY;
 
-        var (id2, base2) = manager.newAuction(beneficiaries, payouts, t1, t2, 100 * T1, 0 * T2, 1 * T2, 1 years);
+        var (id2, base2) = manager.newAuction(beneficiaries, payouts, t1, t2, 100 * T1, 0 * T2, 1, 1 years);
     }
     function testFailNonSummingPayouts() {
         address[] memory beneficiaries = new address[](3);
@@ -314,7 +336,7 @@ contract MultipleBeneficiariesTest is AuctionTest, EventfulAuction, EventfulMana
         payouts[1] = 1;
         payouts[2] = 2;
 
-        var (id2, base2) = manager.newAuction(beneficiaries, payouts, t1, t2, 100 * T1, 0 * T2, 1 * T2, 1 years);
+        var (id2, base2) = manager.newAuction(beneficiaries, payouts, t1, t2, 100 * T1, 0 * T2, 1, 1 years);
     }
     function testFailFirstPayoutLessThanStartBid() {
         address[] memory beneficiaries = new address[](2);
@@ -325,7 +347,7 @@ contract MultipleBeneficiariesTest is AuctionTest, EventfulAuction, EventfulMana
         payouts[0] = 10 * T2;
         payouts[1] = INFINITY - 10 * T2;
 
-        var (id, base) = manager.newAuction(beneficiaries, payouts, t1, t2, 100 * T1, 50 * T2, 1 * T2, 1 years);
+        var (id, base) = manager.newAuction(beneficiaries, payouts, t1, t2, 100 * T1, 50 * T2, 1, 1 years);
     }
     function testPayoutFirstBeneficiary() {
         address[] memory beneficiaries = new address[](2);
@@ -336,7 +358,7 @@ contract MultipleBeneficiariesTest is AuctionTest, EventfulAuction, EventfulMana
         payouts[0] = 10 * T2;
         payouts[1] = INFINITY - 10 * T2;
 
-        var (id, base) = manager.newAuction(beneficiaries, payouts, t1, t2, 100 * T1, 5 * T2, 1 * T2, 1 years);
+        var (id, base) = manager.newAuction(beneficiaries, payouts, t1, t2, 100 * T1, 5 * T2, 1, 1 years);
 
         var balance_before = t2.balanceOf(beneficiary1);
         bidder1.doBid(id, 30 * T2);

--- a/contracts/tests/reverse.sol
+++ b/contracts/tests/reverse.sol
@@ -9,7 +9,7 @@ contract ReverseTest is AuctionTest {
                                         , t2        // buying
                                         , 100 * T1  // max_sell_amount
                                         , 5 * T2    // buy_amount
-                                        , 2 * T1    // min_decrease
+                                        , 2         // min_decrease (%)
                                         , 1 years   // duration
                                         );
     }
@@ -132,5 +132,36 @@ contract ReverseTest is AuctionTest {
         var t1_balance_diff = t1_balance_after - t1_balance_before;
 
         assertEq(t1_balance_diff, 85 * T1);
+    }
+}
+
+contract MinBidDecreaseTest is AuctionTest, EventfulAuction, EventfulManager {
+    function newReverseAuction() returns (uint, uint) {
+        return manager.newReverseAuction( seller    // beneficiary
+                                        , t1        // selling
+                                        , t2        // buying
+                                        , 100 * T1  // max_sell_amount
+                                        , 5 * T2    // buy_amount
+                                        , 20        // min_decrease (%)
+                                        , 1 years   // duration
+                                        );
+    }
+    function testFailFirstBidEqualStartBid() {
+        var (id, base) = newReverseAuction();
+        bidder1.doBid(base, 100 * T1);
+    }
+    function testFailSubsequentBidEqualLastBid() {
+        var (id, base) = newReverseAuction();
+        bidder1.doBid(base, 75 * T1);
+        bidder2.doBid(base, 75 * T1);
+    }
+    function testFailFirstBidLowerThanMinIncrease() {
+        var (id, base) = newReverseAuction();
+        bidder1.doBid(base, 90 * T1);
+    }
+    function testFailSubsequentBidLowerThanMinIncrease() {
+        var (id, base) = newReverseAuction();
+        bidder1.doBid(base, 75 * T1);
+        bidder2.doBid(base, 70 * T1);
     }
 }

--- a/contracts/tests/reverse_splitting.sol
+++ b/contracts/tests/reverse_splitting.sol
@@ -9,7 +9,7 @@ contract ReverseSplittingTest is AuctionTest {
                                         , t2        // buying
                                         , 100 * T1  // sell_amount
                                         , 5 * T2    // buy_amount
-                                        , 2 * T1    // min_decrease
+                                        , 2         // min_decrease (%)
                                         , 1 years   // duration
                                         );
     }

--- a/contracts/tests/splitting_auction.sol
+++ b/contracts/tests/splitting_auction.sol
@@ -13,7 +13,7 @@ contract ForwardSplittingTest is AuctionTest
                                  , t2        // buying
                                  , 100 * T1  // sell_amount
                                  , 10 * T2   // start_bid
-                                 , 1 * T2    // min_increase
+                                 , 1         // min_increase (%)
                                  , 1 years   // duration
                                  );
     }
@@ -273,7 +273,7 @@ contract ForwardSplittingTest is AuctionTest
     function testFailSplitUnderMinIncrease() {
         // Splitting bids have to increase more than the scaled minimum
         // increase
-        var (id, base) = manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 10 * T2, 1 years);
+        var (id, base) = manager.newAuction(seller, t1, t2, 100 * T1, 10 * T2, 10, 1 years);
         bidder1.doBid(base, 10 * T2);
 
         bidder2.doBid(base, 6 * T2, 50 * T1);

--- a/contracts/tests/twoway.sol
+++ b/contracts/tests/twoway.sol
@@ -9,8 +9,8 @@ contract TwoWayTest is AuctionTest, EventfulAuction, EventfulManager {
                                        , t2        // buying
                                        , 100 * T1  // sell_amount
                                        , 10 * T2   // start_bid
-                                       , 1 * T2    // min_increase
-                                       , 1 * T1    // min_decrease
+                                       , 1         // min_increase (%)
+                                       , 1         // min_decrease (%)
                                        , 1 years   // duration
                                        , 100 * T2  // collection_limit
                                        );
@@ -155,8 +155,8 @@ contract TwoWayMultipleBeneficiariesTest is AuctionTest
                                                    , t2
                                                    , 100 * T1
                                                    , 10 * T2
-                                                   , 1 * T2
-                                                   , 1 * T1
+                                                   , 1
+                                                   , 1
                                                    , 1 years
                                                    , 100 * T2
                                                    );
@@ -166,8 +166,8 @@ contract TwoWayMultipleBeneficiariesTest is AuctionTest
                                                    , t2
                                                    , 100 * T1
                                                    , 10 * T2
-                                                   , 1 * T2
-                                                   , 1 * T1
+                                                   , 1
+                                                   , 1
                                                    , 1 years
                                                    );
 
@@ -196,8 +196,8 @@ contract TwoWayMultipleBeneficiariesTest is AuctionTest
                                        , t2
                                        , 100 * T1
                                        , 10 * T2
-                                       , 1 * T2
-                                       , 1 * T1
+                                       , 1
+                                       , 1
                                        , 1 years
                                        );
     }
@@ -316,8 +316,8 @@ contract TwoWayRefundTest is AuctionTest, EventfulAuction, EventfulManager {
                                                         , t2            // buying
                                                         , 100 * T1      // sell_amount
                                                         , 10 * T2       // start_bid
-                                                        , 1 * T2        // min_increase
-                                                        , 1 * T1        // min_decrease
+                                                        , 1             // min_increase (%)
+                                                        , 1             // min_decrease (%)
                                                         , 1 years       // duration
                                                         , 100 * T2      // collection_limit
                                                         );

--- a/contracts/tests/twoway.sol
+++ b/contracts/tests/twoway.sol
@@ -357,7 +357,7 @@ contract TwoWayRefundTest is AuctionTest, EventfulAuction, EventfulManager {
     }
     function testBidNoTransferToBeneficiary() {
         // successive bids in the reverse part of the auction should
-        // send nothing to the creator
+        // send nothing to the given beneficiary
         var (id, base) = newTwoWayAuction();
 
         bidder1.doBid(base, 101 * T2);


### PR DESCRIPTION
Fixes #8.

The supplied `min_increase`, `min_decrease` are now expressed as an integer percentage. Subsequent bids must be greater (or less) than the last by this percentage.

This should lead to faster price discovery.
