### PR TITLE
Prevent re-entry to public functions

### DIFF
--- a/contracts/auction.sol
+++ b/contracts/auction.sol
@@ -226,9 +226,12 @@ contract AuctionFrontend is AuctionFrontendType
                           , EventfulAuction
                           , AssertiveAuction
                           , TwoWayAuction
+                          , MutexUser
 {
     // Place a new bid on a specific auctionlet.
-    function bid(uint auctionlet_id, uint bid_how_much) {
+    function bid(uint auctionlet_id, uint bid_how_much)
+        exclusive
+    {
         assertBiddable(auctionlet_id, bid_how_much);
         doBid(auctionlet_id, msg.sender, bid_how_much);
         Bid(auctionlet_id);
@@ -236,7 +239,9 @@ contract AuctionFrontend is AuctionFrontendType
     // Allow parties to an auction to claim their take.
     // If the auction has expired, individual auctionlet high bidders
     // can claim their winnings.
-    function claim(uint auctionlet_id) {
+    function claim(uint auctionlet_id)
+        exclusive
+    {
         assertClaimable(auctionlet_id);
         doClaim(auctionlet_id);
     }
@@ -247,6 +252,7 @@ contract SplittingAuctionFrontend is SplittingAuctionFrontendType
                                    , EventfulAuction
                                    , AssertiveAuction
                                    , SplittingAuction
+                                   , MutexUser
 {
     // Place a partial bid on an auctionlet, for less than the full lot.
     // This splits the auctionlet into two, bids on one of the new
@@ -254,6 +260,7 @@ contract SplittingAuctionFrontend is SplittingAuctionFrontendType
     // The new auctionlet ids are returned, corresponding to the new
     // auctionlets owned by (prev_bidder, new_bidder).
     function bid(uint auctionlet_id, uint bid_how_much, uint quantity)
+        exclusive
         returns (uint new_id, uint split_id)
     {
         var (, prev_quantity) = getLastBid(auctionlet_id);

--- a/contracts/manager.sol
+++ b/contracts/manager.sol
@@ -71,7 +71,7 @@ contract AuctionController is MathUser
     }
 }
 
-contract AuctionManagerFrontend is AuctionController {
+contract AuctionManagerFrontend is AuctionController, MutexUser {
     uint constant INFINITY = 2 ** 256 - 1;
     // Create a new forward auction.
     // Bidding is done through the auctions associated auctionlets,
@@ -84,6 +84,7 @@ contract AuctionManagerFrontend is AuctionController {
                        , uint min_increase
                        , uint duration
                        )
+        exclusive
         returns (uint auction_id, uint base_id)
     {
         var (beneficiaries, payouts) = _makeSinglePayout(beneficiary, INFINITY);
@@ -111,6 +112,7 @@ contract AuctionManagerFrontend is AuctionController {
                        , uint min_increase
                        , uint duration
                        )
+        exclusive
         returns (uint auction_id, uint base_id)
     {
         (auction_id, base_id) = _makeGenericAuction({ creator: msg.sender
@@ -136,6 +138,7 @@ contract AuctionManagerFrontend is AuctionController {
                               , uint min_decrease
                               , uint duration
                               )
+        exclusive
         returns (uint auction_id, uint base_id)
     {
         var (beneficiaries, payouts) = _makeSinglePayout(beneficiary, 0);
@@ -166,6 +169,7 @@ contract AuctionManagerFrontend is AuctionController {
                               , uint min_decrease
                               , uint duration
                               )
+        exclusive
         returns (uint auction_id, uint base_id)
     {
         var (beneficiaries, payouts) = _makeSinglePayout(beneficiary, 0);
@@ -198,6 +202,7 @@ contract AuctionManagerFrontend is AuctionController {
                              , uint duration
                              , uint collection_limit
                              )
+        exclusive
         returns (uint auction_id, uint base_id)
     {
         var (beneficiaries, payouts) = _makeSinglePayout(beneficiary, collection_limit);
@@ -226,6 +231,7 @@ contract AuctionManagerFrontend is AuctionController {
                              , uint duration
                              , uint collection_limit
                              )
+        exclusive
         returns (uint auction_id, uint base_id)
     {
         var (beneficiaries, payouts) = _makeSinglePayout(beneficiary, collection_limit);
@@ -254,6 +260,7 @@ contract AuctionManagerFrontend is AuctionController {
                              , uint min_decrease
                              , uint duration
                              )
+        exclusive
         returns (uint auction_id, uint base_id)
     {
         var collection_limit = sum(payouts);
@@ -282,6 +289,7 @@ contract AuctionManagerFrontend is AuctionController {
                              , uint min_decrease
                              , uint duration
                              )
+        exclusive
         returns (uint auction_id, uint base_id)
     {
         var collection_limit = sum(payouts);

--- a/contracts/tests/exploit.sol
+++ b/contracts/tests/exploit.sol
@@ -1,0 +1,159 @@
+import 'erc20/base.sol';
+import 'tests/base.sol';
+
+contract MaliciousToken is ERC20Base {
+    TestableManager _manager;
+    uint _auctionlet_id;
+    uint _bid_how_much;
+    uint _quantity;
+
+    enum Attack {Off, Bid, Split, Claim, Done}
+    Attack attack = Attack.Off;
+
+    function MaliciousToken(uint initial_balance)
+        ERC20Base(initial_balance)
+        {}
+    function setTarget(address manager) {
+        _manager = TestableManager(manager);
+    }
+    function setID(uint id) {
+        _auctionlet_id = id;
+    }
+    function setBid(uint bid_how_much) {
+        _bid_how_much = bid_how_much;
+    }
+    function setQuantity(uint quantity) {
+        _quantity = quantity;
+    }
+    function attackBid() {
+        attack = Attack.Bid;
+    }
+    function attackSplit() {
+        attack = Attack.Split;
+    }
+    function attackClaim() {
+        attack = Attack.Claim;
+    }
+    function attackOff() {
+        attack = Attack.Off;
+    }
+    function attackDone() {
+        attack = Attack.Done;
+    }
+    function transferFrom(address from, address to, uint amount)
+        returns (bool ok)
+    {
+        if (attack == Attack.Done) {
+            return true;
+        } else if (attack == Attack.Bid) {
+            attackDone();
+            _manager.bid(_auctionlet_id, _bid_how_much, _quantity);
+        } else if (attack == Attack.Split) {
+            attackDone();
+            _manager.bid(_auctionlet_id, _bid_how_much, _quantity);
+        } else {
+            super.transferFrom(from, to, amount);
+        }
+        return true;
+    }
+    function transfer(address to, uint amount)
+        returns (bool ok)
+    {
+        if (attack == Attack.Done) {
+            return true;
+        } else if (attack == Attack.Claim) {
+            attackDone();
+            _manager.claim(_auctionlet_id);
+            return true;
+        } else {
+            return super.transfer(to, amount);
+        }
+    }
+}
+
+contract ExploitTest is AuctionTest {
+    MaliciousToken mtoken;
+    uint constant TM = 5 ** 9;
+
+    function newMaliciousBidAuction() returns (uint, uint) {
+        return manager.newAuction( seller    // beneficiary
+                                 , t1        // selling
+                                 , mtoken    // buying
+                                 , 100 * T1  // sell_amount
+                                 , 10 * TM   // start_bid
+                                 , 1         // min_increase (%)
+                                 , 1 years   // duration
+                                 );
+    }
+    function newMaliciousClaimAuction() returns (uint, uint) {
+        return manager.newAuction( seller    // beneficiary
+                                 , mtoken    // selling
+                                 , t2        // buying
+                                 , 100 * TM  // sell_amount
+                                 , 10 * T2   // start_bid
+                                 , 1         // min_increase (%)
+                                 , 1 years   // duration
+                                 );
+    }
+    function exploitSetUp () returns (uint) ;
+    function testSetUp() {
+        exploitSetUp();
+    }
+}
+
+contract BidExploitTest is ExploitTest {
+    function exploitSetUp () returns (uint) {
+        mtoken = new MaliciousToken(10 ** 6 * TM);
+        var (id, base) = newMaliciousBidAuction();
+
+        mtoken.setTarget(manager);
+        mtoken.setID(base);
+        mtoken.setBid(30 * TM);
+        mtoken.setQuantity(100 * T1);
+        mtoken.attackBid();
+        return base;
+    }
+    function testFailReEntrantBid() {
+        var base = exploitSetUp();
+        manager.bid(base, 20 * TM, 100 * T1);
+    }
+}
+
+contract SplitExploitTest is ExploitTest {
+    function exploitSetUp () returns (uint) {
+        mtoken = new MaliciousToken(10 ** 6 * TM);
+        var (id, base) = newMaliciousBidAuction();
+
+        mtoken.setTarget(manager);
+        mtoken.setID(base);
+        mtoken.setBid(30 * TM);
+        mtoken.setQuantity(50 * TM);
+        mtoken.attackSplit();
+        return base;
+    }
+    function testFailReEntrantSplit() {
+        var base = exploitSetUp();
+        manager.bid(base, 20 * TM, 80 * T1);
+    }
+}
+
+contract ClaimExploitTest is ExploitTest {
+    function exploitSetUp () returns (uint) {
+        mtoken = new MaliciousToken(10 ** 6 * TM);
+        mtoken.approve(manager, 100 * TM);
+        var (id, base) = newMaliciousClaimAuction();
+
+        mtoken.setTarget(manager);
+        mtoken.setID(base);
+
+        manager.bid(base, 20 * T2, 100 * TM);
+        manager.addTime(2 years);
+
+        mtoken.attackClaim();
+        return base;
+    }
+    function testFailReEntrantClaim() {
+        var base = exploitSetUp();
+        manager.claim(base);
+    }
+}

--- a/contracts/util.sol
+++ b/contracts/util.sol
@@ -48,7 +48,7 @@ contract MathUser {
 }
 
 contract MutexUser {
-    bool mutex_lock;
+    bool private mutex_lock;
     modifier exclusive {
         if (mutex_lock) throw;
         mutex_lock = true;

--- a/contracts/util.sol
+++ b/contracts/util.sol
@@ -46,3 +46,13 @@ contract MathUser {
         }
     }
 }
+
+contract MutexUser {
+    bool mutex_lock;
+    modifier exclusive {
+        if (mutex_lock) throw;
+        mutex_lock = true;
+        _
+        mutex_lock = false;
+    }
+}


### PR DESCRIPTION
Add a mutex to protect public functions from re-entry by a malicious token. Fixes #16 (for now :grimacing:).
