### PR TITLE
allow refund as argument in initialisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,15 +317,53 @@ quantities of the `sell_token` are forgone by bidders.
 
 The default behaviour is to refund this excess `sell_token` to the
 (first) beneficiary. It is possible for the auction *creator* to set
-the refund address arbitrarily.
+the refund address arbitrarily when creating the auction.
 
-After creating an auction:
+Reverse auction:
 
 ```
-manager.setRefundAddress(auction_id, some_arbitrary_address);
+var (id, base) = manager.newReverseAuction( beneficiary
+                                          , refund
+                                          , sell_token
+                                          , buy_token
+                                          , max_sell_amount
+                                          , buy_amount
+                                          , min_decrease
+                                          , duration
+                                          )
 ```
 
-Note that this address can be set any number of times to any number
-of addresses during the course of the auction. Accordingly a
-beneficiary expecting funds needs to trust, or be controlled by, the
-auction creator.
+Single beneficiary two-way auction:
+
+```
+var (id, base) = manager.newTwoWayAuction( beneficiary
+                                         , refund
+                                         , sell_token
+                                         , buy_token
+                                         , sell_amount
+                                         , start_bid
+                                         , min_increase
+                                         , min_decrease
+                                         , duration
+                                         , collection_limit
+                                         )
+```
+
+Multi beneficiary two-way auction:
+
+```
+var (id, base) = manager.newTwoWayAuction( beneficiaries
+                                         , payouts
+                                         , refund
+                                         , sell_token
+                                         , buy_token
+                                         , sell_amount
+                                         , start_bid
+                                         , min_increase
+                                         , min_decrease
+                                         , duration
+                                         );
+```
+
+- `address refund` is the address that forgone `sell_token` will be
+  sent to, continuously.

--- a/contracts/db.sol
+++ b/contracts/db.sol
@@ -57,15 +57,10 @@ contract UsingAuctionDatabase is AuctionDatabase {
         return _auctions[auction_id].refund;
     }
     function setRefundAddress(uint auction_id, address refund)
-        only_creator(auction_id)
+        internal
     {
         var A = _auctions[auction_id];
         A.refund = refund;
-    }
-    modifier only_creator(uint auction_id) {
-        if (msg.sender != _auctions[auction_id].creator)
-            throw;
-        _
     }
     // Auctionlet bid update logic.
     function newBid(uint auctionlet_id, address bidder, uint bid_how_much) {

--- a/contracts/manager.sol
+++ b/contracts/manager.sol
@@ -121,6 +121,37 @@ contract AuctionManager is UsingMath, AuctionType, EventfulManager, AuctionUser 
                                                     , reversed: true
                                                     });
     }
+    // Create a new reverse auction
+    function newReverseAuction( address beneficiary
+                              , address refund
+                              , ERC20 selling
+                              , ERC20 buying
+                              , uint max_sell_amount
+                              , uint buy_amount
+                              , uint min_decrease
+                              , uint duration
+                              )
+        returns (uint auction_id, uint base_id)
+    {
+        var (beneficiaries, payouts) = _makeSinglePayout(beneficiary, 0);
+
+        // the Reverse Auction is the limit of the two way auction
+        // where the maximum collected buying token is zero.
+        (auction_id, base_id) = _makeGenericAuction({ creator: msg.sender
+                                                    , beneficiaries: beneficiaries
+                                                    , payouts: payouts
+                                                    , selling: selling
+                                                    , buying: buying
+                                                    , sell_amount: max_sell_amount
+                                                    , start_bid: buy_amount
+                                                    , min_increase: 0
+                                                    , min_decrease: min_decrease
+                                                    , duration: duration
+                                                    , collection_limit: 0
+                                                    , reversed: true
+                                                    });
+        setRefundAddress(auction_id, refund);
+    }
     // Create a new two-way auction.
     function newTwoWayAuction( address beneficiary
                              , ERC20 selling
@@ -132,22 +163,51 @@ contract AuctionManager is UsingMath, AuctionType, EventfulManager, AuctionUser 
                              , uint duration
                              , uint collection_limit
                              )
-        returns (uint, uint)
+        returns (uint auction_id, uint base_id)
     {
         var (beneficiaries, payouts) = _makeSinglePayout(beneficiary, collection_limit);
-        return _makeGenericAuction({ creator: msg.sender
-                                   , beneficiaries: beneficiaries
-                                   , payouts: payouts
-                                   , selling: selling
-                                   , buying: buying
-                                   , sell_amount: sell_amount
-                                   , start_bid: start_bid
-                                   , min_increase: min_increase
-                                   , min_decrease: min_decrease
-                                   , duration: duration
-                                   , collection_limit: collection_limit
-                                   , reversed: false
-                                   });
+        (auction_id, base_id) = _makeGenericAuction({ creator: msg.sender
+                                                    , beneficiaries: beneficiaries
+                                                    , payouts: payouts
+                                                    , selling: selling
+                                                    , buying: buying
+                                                    , sell_amount: sell_amount
+                                                    , start_bid: start_bid
+                                                    , min_increase: min_increase
+                                                    , min_decrease: min_decrease
+                                                    , duration: duration
+                                                    , collection_limit: collection_limit
+                                                    , reversed: false
+                                                    });
+    }
+    function newTwoWayAuction( address beneficiary
+                             , address refund
+                             , ERC20 selling
+                             , ERC20 buying
+                             , uint sell_amount
+                             , uint start_bid
+                             , uint min_increase
+                             , uint min_decrease
+                             , uint duration
+                             , uint collection_limit
+                             )
+        returns (uint auction_id, uint base_id)
+    {
+        var (beneficiaries, payouts) = _makeSinglePayout(beneficiary, collection_limit);
+        (auction_id, base_id) =  _makeGenericAuction({ creator: msg.sender
+                                                     , beneficiaries: beneficiaries
+                                                     , payouts: payouts
+                                                     , selling: selling
+                                                     , buying: buying
+                                                     , sell_amount: sell_amount
+                                                     , start_bid: start_bid
+                                                     , min_increase: min_increase
+                                                     , min_decrease: min_decrease
+                                                     , duration: duration
+                                                     , collection_limit: collection_limit
+                                                     , reversed: false
+                                                     });
+        setRefundAddress(auction_id, refund);
     }
     function newTwoWayAuction( address[] beneficiaries
                              , uint[] payouts
@@ -159,10 +219,38 @@ contract AuctionManager is UsingMath, AuctionType, EventfulManager, AuctionUser 
                              , uint min_decrease
                              , uint duration
                              )
-        returns (uint, uint)
+        returns (uint auction_id, uint base_id)
     {
         var collection_limit = sum(payouts);
-        return _makeGenericAuction({ creator: msg.sender
+        (auction_id, base_id) =  _makeGenericAuction({ creator: msg.sender
+                                                     , beneficiaries: beneficiaries
+                                                     , payouts: payouts
+                                                     , selling: selling
+                                                     , buying: buying
+                                                     , sell_amount: sell_amount
+                                                     , start_bid: start_bid
+                                                     , min_increase: min_increase
+                                                     , min_decrease: min_decrease
+                                                     , duration: duration
+                                                     , collection_limit: collection_limit
+                                                     , reversed: false
+                                                     });
+    }
+    function newTwoWayAuction( address[] beneficiaries
+                             , uint[] payouts
+                             , address refund
+                             , ERC20 selling
+                             , ERC20 buying
+                             , uint sell_amount
+                             , uint start_bid
+                             , uint min_increase
+                             , uint min_decrease
+                             , uint duration
+                             )
+        returns (uint auction_id, uint base_id)
+    {
+        var collection_limit = sum(payouts);
+        (auction_id, base_id) = _makeGenericAuction({ creator: msg.sender
                                    , beneficiaries: beneficiaries
                                    , payouts: payouts
                                    , selling: selling
@@ -175,6 +263,7 @@ contract AuctionManager is UsingMath, AuctionType, EventfulManager, AuctionUser 
                                    , collection_limit: collection_limit
                                    , reversed: false
                                    });
+        setRefundAddress(auction_id, refund);
     }
     function _makeSinglePayout(address beneficiary, uint collection_limit)
         internal

--- a/contracts/tests/db.sol
+++ b/contracts/tests/db.sol
@@ -5,9 +5,6 @@ contract DBTester is Tester {
     function bindManager(address manager) {
         _manager = TestableManager(manager);
     }
-    function doSetRefundAddress(uint id, address refund) {
-        _manager.setRefundAddress(id, refund);
-    }
 }
 
 contract AuctionDBTest is AuctionTest {
@@ -27,19 +24,5 @@ contract AuctionDBTest is AuctionTest {
         var (id, base) = newAuction();
 
         assertEq(manager.getRefundAddress(id), seller);
-    }
-    function testSetRefund() {
-        var (id, base) = newAuction();
-
-        manager.setRefundAddress(id, beneficiary2);
-        assertEq(manager.getRefundAddress(id), beneficiary2);
-    }
-    function testFailSetRefundNotCreator() {
-        var (id, base) = newAuction();
-
-        tester = new DBTester();
-        tester.bindManager(manager);
-
-        tester.doSetRefundAddress(id, beneficiary2);
     }
 }

--- a/contracts/tests/reverse.sol
+++ b/contracts/tests/reverse.sol
@@ -163,3 +163,21 @@ contract MinBidDecreaseTest is AuctionTest {
         bidder2.doBid(base, 70 * T1);
     }
 }
+
+contract ReverseRefundTest is AuctionTest {
+    function newTwoWayAuction() returns (uint, uint) {
+        return manager.newReverseAuction( seller        // beneficiary
+                                        , beneficiary1  // refund
+                                        , t1            // selling
+                                        , t2            // buying
+                                        , 100 * T1      // max_sell_amount
+                                        , 5 * T2        // buy_amount
+                                        , 20            // min_decrease (%)
+                                        , 1 years       // duration
+                                        );
+    }
+    function testNewReverseAuction() {
+        var (id, base) = newTwoWayAuction();
+        assertEq(manager.getRefundAddress(id), beneficiary1);
+    }
+}

--- a/contracts/tests/twoway.sol
+++ b/contracts/tests/twoway.sol
@@ -308,6 +308,7 @@ contract TwoWayMultipleBeneficiariesTest is AuctionTest
 contract TwoWayRefundTest is AuctionTest {
     function newTwoWayAuction() returns (uint auction_id, uint base_id) {
         (auction_id, base_id) = manager.newTwoWayAuction( seller        // beneficiary
+                                                        , beneficiary1  // refund
                                                         , t1            // selling
                                                         , t2            // buying
                                                         , 100 * T1      // sell_amount
@@ -317,7 +318,6 @@ contract TwoWayRefundTest is AuctionTest {
                                                         , 1 years       // duration
                                                         , 100 * T2      // collection_limit
                                                         );
-        manager.setRefundAddress(auction_id, beneficiary1);
     }
     function testNewTwoWayAuction() {
         var (id, base) = newTwoWayAuction();


### PR DESCRIPTION
Some earlier refactoring removed the stack depth issues that were preventing this before (see #13).

Also remove the creators ability to set the refund after creating the auction. This required a level of trust in the creator.

There are now 7 different auction initialisers. Might make sense to remove a couple and force the creator to specify the refund address. Once we have optional / additional args this will be easier:

https://github.com/ethereum/solidity/issues/232
https://github.com/ethereum/solidity/issues/240
