### PR TITLE
Refactor bid monolith, make side effects explicit

### DIFF
--- a/contracts/auction.sol
+++ b/contracts/auction.sol
@@ -23,6 +23,9 @@ contract SplittingAuction is AuctionType
             a.base = false;
         }
 
+        // Forward auctions increment the total auction collection on
+        // each bid. In reverse auctions this is unchanged per bid as
+        // bids compete on the sell side.
         if (!A.reversed) {
             var excess_buy = bid_how_much - a.buy_amount;
             A.collected += excess_buy;

--- a/contracts/auction.sol
+++ b/contracts/auction.sol
@@ -124,7 +124,7 @@ contract SplittingAuction is AuctionType
         internal
         returns (uint new_id, uint split_id)
     {
-        var a = _auctionlets[auctionlet_id];
+        var a = readAuctionlet(auctionlet_id);
 
         var (new_quantity, new_bid, split_bid) = _calculate_split(auctionlet_id, quantity);
 
@@ -155,8 +155,8 @@ contract SplittingAuction is AuctionType
     function doClaim(uint auctionlet_id)
         internal
     {
-        var a = _auctionlets[auctionlet_id];
-        var A = _auctions[a.auction_id];
+        var a = readAuctionlet(auctionlet_id);
+        var A = readAuction(a.auction_id);
 
         settleBidderClaim(A, a);
 
@@ -168,8 +168,8 @@ contract SplittingAuction is AuctionType
 contract AssertiveAuction is Assertive, AuctionDatabaseUser {
     // Check whether an auctionlet is eligible for bidding on
     function assertBiddable(uint auctionlet_id, uint bid_how_much) internal {
-        var a = _auctionlets[auctionlet_id];
-        var A = _auctions[a.auction_id];
+        var a = readAuctionlet(auctionlet_id);
+        var A = readAuction(a.auction_id);
 
         assert(a.auction_id > 0);  // test for deleted auction
         assert(auctionlet_id > 0);  // test for deleted auctionlet
@@ -203,8 +203,8 @@ contract AssertiveAuction is Assertive, AuctionDatabaseUser {
     }
     // Check whether an auctionlet can be claimed.
     function assertClaimable(uint auctionlet_id) internal {
-        var a = _auctionlets[auctionlet_id];
-        var A = _auctions[a.auction_id];
+        var a = readAuctionlet(auctionlet_id);
+        var A = readAuction(a.auction_id);
 
         // must be expired
         assert(isExpired(auctionlet_id));

--- a/contracts/auction.sol
+++ b/contracts/auction.sol
@@ -134,10 +134,9 @@ contract SplittingAuction is AuctionType
         split_id = newAuctionlet(a.auction_id, split_bid, quantity,
                                  a.last_bidder, a.base);
 
+        deleteAuctionlet(auctionlet_id);
         newBid(new_id, a.last_bidder, new_bid);
         doBid(split_id, splitter, bid_how_much);
-
-        deleteAuctionlet(auctionlet_id);
     }
     // Work out how to split a bid into two parts
     function _calculate_split(uint auctionlet_id, uint quantity)
@@ -158,10 +157,10 @@ contract SplittingAuction is AuctionType
         var a = readAuctionlet(auctionlet_id);
         var A = readAuction(a.auction_id);
 
-        settleBidderClaim(A, a);
-
         a.unclaimed = false;
         deleteAuctionlet(auctionlet_id);
+
+        settleBidderClaim(A, a);
     }
 }
 

--- a/contracts/db.sol
+++ b/contracts/db.sol
@@ -1,6 +1,9 @@
 import 'types.sol';
 import 'util.sol';
 
+// CRUD database for auctions and auctionlets. Create, Read(only) and
+// Delete are done with methods here. For gas reasons, Update is done by
+// explicitly modifiying storage (i.e. accessing _auctions / _auctionlets).
 contract AuctionDatabase is AuctionType {
     mapping(uint => Auction) _auctions;
     uint _last_auction_id;
@@ -15,6 +18,20 @@ contract AuctionDatabase is AuctionType {
     function createAuction(Auction A) internal returns (uint id) {
         id = ++_last_auction_id;
         _auctions[id] = A;
+    }
+    function readAuctionlet(uint auctionlet_id)
+        internal
+        constant
+        returns (Auctionlet memory a)
+    {
+        a = _auctionlets[auctionlet_id];
+    }
+    function readAuction(uint auction_id)
+        internal
+        constant
+        returns (Auction memory A)
+    {
+        A = _auctions[auction_id];
     }
     function deleteAuctionlet(uint auctionlet_id) internal {
         delete _auctionlets[auctionlet_id];
@@ -77,8 +94,8 @@ contract AuctionDatabaseUser is AuctionDatabase, TimeUser {
         constant
         returns (uint prev_bid, uint prev_quantity)
     {
-        var a = _auctionlets[auctionlet_id];
-        var A = _auctions[a.auction_id];
+        var a = readAuctionlet(auctionlet_id);
+        var A = readAuction(a.auction_id);
 
         if (A.reversed) {
             prev_bid = a.sell_amount;

--- a/contracts/manager.sol
+++ b/contracts/manager.sol
@@ -283,7 +283,7 @@ contract AuctionManager is MathUser
                                                   , reversed: reversed
                                                   });
 
-        var A = _auctions[auction_id];
+        var A = readAuction(auction_id);
 
         assertConsistentPayouts(A);
         takeFundsIntoEscrow(A);

--- a/contracts/tests/db.sol
+++ b/contracts/tests/db.sol
@@ -1,9 +1,38 @@
 import 'tests/base.sol';
+import 'db.sol';
 
 contract DBTester is Tester {
     TestableManager _manager;
     function bindManager(address manager) {
         _manager = TestableManager(manager);
+    }
+}
+
+contract CRUDTest is AuctionTest, AuctionDatabase {
+    AuctionDatabase _db;
+
+    function setUp() {
+        _db = new AuctionDatabase();
+
+        Auction memory auction;
+        createAuction(auction);
+
+        Auctionlet memory auctionlet;
+        createAuctionlet(auctionlet);
+    }
+    function testReadOnlyAuction() {
+        var A = readAuction(1);
+
+        assertEq(_auctions[1].duration, 0);
+        A.duration = 100 years;
+        assertEq(_auctions[1].duration, 0);
+    }
+    function testReadOnlyAuctionlet() {
+        var a = readAuctionlet(1);
+
+        assertEq(_auctionlets[1].base, false);
+        a.base = true;
+        assertEq(_auctionlets[1].base, false);
     }
 }
 

--- a/contracts/transfer.sol
+++ b/contracts/transfer.sol
@@ -12,8 +12,11 @@ contract TransferUser is Assertive, MathUser, AuctionType {
     function takeFundsIntoEscrow(Auction A) internal {
         assert(A.selling.transferFrom(A.creator, this, A.sell_amount));
     }
-    function payOffLastBidder(Auction A, Auctionlet a, address bidder) internal {
-        assert(A.buying.transferFrom(bidder, a.last_bidder, a.buy_amount));
+    function payOffLastBidder(Auction A, Auctionlet a,
+                              address new_bidder, address prev_bidder, uint how_much)
+        internal
+    {
+        assert(A.buying.transferFrom(new_bidder, prev_bidder, how_much));
     }
     function settleExcessBuy(Auction A, address bidder, uint excess_buy) internal {
         if (A.beneficiaries.length == 1) {

--- a/contracts/transfer.sol
+++ b/contracts/transfer.sol
@@ -8,6 +8,10 @@ import 'util.sol';
 // transfer methods of the buying / selling token. Bear this in mind if
 // the auction allows arbitrary tokens to be added, as they could be
 // malicious.
+//
+// These methods take Auction(lets) as arguments to allow them to do
+// complex settlement logic. However, their access to the auction is
+// read-only - they cannot write to storage.
 contract TransferUser is Assertive, MathUser, AuctionType {
     function takeFundsIntoEscrow(Auction A) internal {
         assert(A.selling.transferFrom(A.creator, this, A.sell_amount));
@@ -19,13 +23,24 @@ contract TransferUser is Assertive, MathUser, AuctionType {
         assert(A.buying.transferFrom(new_bidder, prev_bidder, how_much));
     }
     function settleExcessBuy(Auction A, address bidder, uint excess_buy) internal {
+        // if there is only a single beneficiary, they get all of the
+        // settlement.
         if (A.beneficiaries.length == 1) {
             assert(A.buying.transferFrom(bidder, A.beneficiaries[0], excess_buy));
             return;
         }
 
-        var prev_collected = A.collected - excess_buy;
+        // If there are multiple beneficiaries, the settlement must be
+        // shared out. Each beneficiary has an associated payout, which
+        // is the maximum they can receive from the auction. As the
+        // auction collects more funds, beneficiaries receive their
+        // payouts in turn. The per bid settlement could span multiple
+        // payouts - the logic below partitions the settlement as
+        // needed.
 
+        // collection state prior to this bid
+        var prev_collected = A.collected - excess_buy;
+        // payout transition limits
         var limits = cumsum(A.payouts);
 
         for (uint i = 0; i < limits.length; i++) {


### PR DESCRIPTION
Refactoring of the central bid method to make it clearer in its effects.

Also makes all external token interactions the final step in the process for bid, split and claim.

Builds on #22.
