### PR TITLE
Split gas optimisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ the number of times an auction can be split.
 
 The splittable unit of an auction is an **auctionlet**. Each auction
 initially has a single auctionlet. Auctionlets are the object on
-which bidders place bids. Splitting an auctionlet produces two new
-auctionlets (both of reduced quantity) and deletes the old one.
+which bidders place bids. Splitting an auctionlet produces a new
+auctionlet of reduced quantity and reduces the available quantity in
+the original auctionlet.
 
 The auctions are **continuous**. The auction beneficiaries are
 continually rewarded as new bids are made: by increasing amounts of
@@ -195,12 +196,10 @@ import 'token-auction/types.sol';
 manager = SplittingAuctionFrontendType(known_manager_address);
 ```
 
-Users interact with active auctions via `bid` and `claim`. The `bid`
-function can be called in two different ways - regular *bids* and
-*splits*.
+Users interact with active auctions via `bid` and `claim`.
 
 
-**Bid** on an auctionlet:
+**Bid** on a non splitting auction:
 
 ```
 manager.bid(id, bid_amount)
@@ -215,16 +214,18 @@ so they must `approve` it first. The excess `buy_token` given by the
 bid (over the last) is sent directly to the `beneficiary`.
 
 
-**Split** an auctionlet:
+**Bid** on a splitting auction:
 
 ```
 var (new_id, split_id) = manager.bid(id, bid_amount, split_amount)
 ```
 
-- `uint split_amount` is the reduced quantity of `sell_token` on
-  which the new bid is being made.
+- `uint split_amount` is the quantity of `sell_token` on which the
+  new bid is being made. If the amount is equal to the existing
+  quantity, then a regular bid is performed; if it is less, then a
+  split bid is performed.
 
-Splitting returns a pair of identifiers:
+Bidding on a splitting auction returns a pair of identifiers:
 
 - `uint split_id` refers to the auctionlet on which the caller is
   now the highest bidder.
@@ -281,12 +282,14 @@ Split(uint base_id, uint new_id, uint split_id)
 ```
 
 - `uint base_id` is the id of the auctionlet that has been split
-  (and deleted).
-- `uint new_id` is the id of the new auctionlet that the previous
+- `uint new_id` is the id of the auctionlet that the previous
   bidder retains.
 - `uint split_id` is the id of the new auctionlet that the splitter
   is now the high bidder on.
 
+Note that while `new_id == base_id` at present, this isn't
+guaranteed to be the case in the future and you should use `new_id`
+as the new identifier.
 
 ## Advanced Usage
 

--- a/contracts/auction.sol
+++ b/contracts/auction.sol
@@ -130,7 +130,6 @@ contract SplittingAuction is AuctionType
 
         // modify the old auctionlet
         setLastBid(auctionlet_id, new_bid, new_quantity);
-        newBid(auctionlet_id, a.last_bidder, new_bid);
         new_id = auctionlet_id;
 
         // create a new auctionlet with the split quantity

--- a/contracts/auction.sol
+++ b/contracts/auction.sol
@@ -248,12 +248,6 @@ contract SplittingAuctionFrontend is SplittingAuctionFrontendType
                                    , AssertiveAuction
                                    , SplittingAuction
 {
-    // Place a new bid on a specific auctionlet.
-    function bid(uint auctionlet_id, uint bid_how_much) {
-        assertBiddable(auctionlet_id, bid_how_much);
-        doBid(auctionlet_id, msg.sender, bid_how_much);
-        Bid(auctionlet_id);
-    }
     // Place a partial bid on an auctionlet, for less than the full lot.
     // This splits the auctionlet into two, bids on one of the new
     // auctionlets and leaves the other to the previous bidder.
@@ -262,9 +256,16 @@ contract SplittingAuctionFrontend is SplittingAuctionFrontendType
     function bid(uint auctionlet_id, uint bid_how_much, uint quantity)
         returns (uint new_id, uint split_id)
     {
-        assertSplittable(auctionlet_id, bid_how_much, quantity);
-        (new_id, split_id) = doSplit(auctionlet_id, msg.sender, bid_how_much, quantity);
-        Split(auctionlet_id, new_id, split_id);
+        var (, prev_quantity) = getLastBid(auctionlet_id);
+        if (quantity == prev_quantity) {
+            assertBiddable(auctionlet_id, bid_how_much);
+            doBid(auctionlet_id, msg.sender, bid_how_much);
+            Bid(auctionlet_id);
+        } else {
+            assertSplittable(auctionlet_id, bid_how_much, quantity);
+            (new_id, split_id) = doSplit(auctionlet_id, msg.sender, bid_how_much, quantity);
+            Split(auctionlet_id, new_id, split_id);
+        }
     }
     // Allow parties to an auction to claim their take.
     // If the auction has expired, individual auctionlet high bidders

--- a/contracts/auction.sol
+++ b/contracts/auction.sol
@@ -124,18 +124,18 @@ contract SplittingAuction is AuctionType
         internal
         returns (uint new_id, uint split_id)
     {
-        var a = readAuctionlet(auctionlet_id);
+        var a = _auctionlets[auctionlet_id];
 
         var (new_quantity, new_bid, split_bid) = _calculate_split(auctionlet_id, quantity);
 
-        // create two new auctionlets and bid on them
-        new_id = newAuctionlet(a.auction_id, new_bid, new_quantity,
-                               a.last_bidder, a.base);
+        // modify the old auctionlet
+        setLastBid(auctionlet_id, new_bid, new_quantity);
+        newBid(auctionlet_id, a.last_bidder, new_bid);
+        new_id = auctionlet_id;
+
+        // create a new auctionlet with the split quantity
         split_id = newAuctionlet(a.auction_id, split_bid, quantity,
                                  a.last_bidder, a.base);
-
-        deleteAuctionlet(auctionlet_id);
-        newBid(new_id, a.last_bidder, new_bid);
         doBid(split_id, splitter, bid_how_much);
     }
     // Work out how to split a bid into two parts

--- a/contracts/db.sol
+++ b/contracts/db.sol
@@ -63,7 +63,6 @@ contract AuctionDatabaseUser is AuctionDatabase, TimeUser {
         auctionlet.unclaimed = true;
         auctionlet.last_bidder = last_bidder;
         auctionlet.base = base;
-        auctionlet.last_bid_time = getTime();
 
         auctionlet_id = createAuctionlet(auctionlet);
 

--- a/contracts/db.sol
+++ b/contracts/db.sol
@@ -138,7 +138,6 @@ contract AuctionDatabaseUser is AuctionDatabase, TimeUser {
         A.refund = refund;
     }
     function getLastBid(uint auctionlet_id)
-        internal
         constant
         returns (uint prev_bid, uint prev_quantity)
     {

--- a/contracts/db.sol
+++ b/contracts/db.sol
@@ -138,18 +138,6 @@ contract AuctionDatabaseUser is AuctionDatabase, TimeUser {
         var A = _auctions[auction_id];
         A.refund = refund;
     }
-    // Auctionlet bid update logic.
-    function newBid(uint auctionlet_id, address bidder, uint bid_how_much)
-        internal
-    {
-        var a = _auctionlets[auctionlet_id];
-        var A = _auctions[a.auction_id];
-
-        var quantity = A.reversed ? a.buy_amount : a.sell_amount;
-
-        setLastBid(auctionlet_id, bid_how_much, quantity);
-        a.last_bidder = bidder;
-    }
     function getLastBid(uint auctionlet_id)
         internal
         constant

--- a/contracts/tests/base.sol
+++ b/contracts/tests/base.sol
@@ -35,15 +35,18 @@ contract TestableManager is SplittingAuctionManager {
 
 contract AuctionTester is Tester {
     SplittingAuctionFrontendType frontend;
+    AuctionDatabaseUser db;
     function bindManager(address manager) {
         frontend = SplittingAuctionFrontendType(manager);
+        db = AuctionDatabaseUser(manager);
     }
     function doApprove(address spender, uint value, ERC20 token) {
         token.approve(spender, value);
     }
     function doBid(uint auctionlet_id, uint bid_how_much)
     {
-        return frontend.bid(auctionlet_id, bid_how_much);
+        var (, quantity) = db.getLastBid(auctionlet_id);
+        frontend.bid(auctionlet_id, bid_how_much, quantity);
     }
     function doBid(uint auctionlet_id, uint bid_how_much, uint sell_amount)
         returns (uint, uint)

--- a/contracts/tests/splitting_auction.sol
+++ b/contracts/tests/splitting_auction.sol
@@ -314,13 +314,6 @@ contract ForwardSplittingTest is AuctionTest
 
         assertEq(balance_after - balance_before, 50 * T2);
     }
-    function testFailBidAfterSplit() {
-        // splitting deletes the old auctionlet_id
-        // bidding on this id should error
-        var (id, base) = newAuction();
-        var (nid, sid) = bidder2.doBid(base, 12 * T2, 60 * T1);
-        bidder1.doBid(base, 11 * T2);
-    }
     function testFailSplitAfterSplit() {
         // splitting deletes the old auctionlet_id
         // splitting on this id should error

--- a/contracts/types.sol
+++ b/contracts/types.sol
@@ -34,7 +34,8 @@ contract AuctionFrontendType {
     function claim(uint auctionlet_id);
 }
 
-contract SplittingAuctionFrontendType is AuctionFrontendType {
+contract SplittingAuctionFrontendType {
     function bid(uint auctionlet_id, uint bid_how_much, uint quantity)
         returns (uint new_id, uint split_id);
+    function claim(uint auctionlet_id);
 }

--- a/dappfile
+++ b/dappfile
@@ -13,4 +13,4 @@ environments:
     objects:
       auction:
         class: SplittingAuctionManager
-        address: '0x6d9b31ef99a61aadc816cc5a3c57ab0c800979b6'
+        address: '0x49a392153fb11a3446cd6953333f24a2e295312f'


### PR DESCRIPTION
Addressing #31.

Change split process from split(i) -> j, k to split(i) -> i', j.
That is, modify the existing auctionlet rather than deleting it and creating a new
one.

Note that this gives an important change to auction semantics: previously,
the quantity being bid on in an auctionlet was invariant. Now, bidders cannot
be assured that a given auctionlet will maintain the bid quantity they know it
to have.

External agents must pay close attention to the auction event stream, or they
could end up successfully bidding for a much lower quantity than they expected.

Gas before:
    - base split: 448k
    - non base split: 418k

Gas after:
    - base split: 280k
    - non base split: 234k
