### PR TITLE
Put bid price info in Bid event

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,11 +269,12 @@ AuctionReversal(uint indexed auction_id)
 Successful new **bid** on an auctionlet:
 
 ```
-Bid(uint indexed auctionlet_id)
+Bid(uint indexed auctionlet_id, uint bid_price)
 ```
 
 - `uint auctionlet_id` is the id of the auctionlet that has been bid
   on.
+- `uint bid_price` is the price of the bid.
 
 Successful **split** of an auctionlet:
 

--- a/contracts/auction.sol
+++ b/contracts/auction.sol
@@ -234,7 +234,7 @@ contract AuctionFrontend is AuctionFrontendType
     {
         assertBiddable(auctionlet_id, bid_how_much);
         doBid(auctionlet_id, msg.sender, bid_how_much);
-        Bid(auctionlet_id);
+        Bid(auctionlet_id, bid_how_much);
     }
     // Allow parties to an auction to claim their take.
     // If the auction has expired, individual auctionlet high bidders
@@ -268,7 +268,7 @@ contract SplittingAuctionFrontend is SplittingAuctionFrontendType
             assertBiddable(auctionlet_id, bid_how_much);
             doBid(auctionlet_id, msg.sender, bid_how_much);
             new_id = auctionlet_id;
-            Bid(auctionlet_id);
+            Bid(auctionlet_id, bid_how_much);
         } else {
             assertSplittable(auctionlet_id, bid_how_much, quantity);
             (new_id, split_id) = doSplit(auctionlet_id, msg.sender, bid_how_much, quantity);

--- a/contracts/events.sol
+++ b/contracts/events.sol
@@ -1,5 +1,5 @@
 contract EventfulAuction {
-    event Bid(uint indexed auctionlet_id);
+    event Bid(uint indexed auctionlet_id, uint bid_price);
     event Split(uint base_id, uint new_id, uint split_id);
     event AuctionReversal(uint indexed auction_id);
 }

--- a/contracts/tests/auction_manager.sol
+++ b/contracts/tests/auction_manager.sol
@@ -28,8 +28,8 @@ contract AuctionManagerTest is AuctionTest {
 
         expectEventsExact(manager);
         NewAuction(id, base);
-        Bid(base);
-        Bid(base);
+        Bid(base, 11 * T2);
+        Bid(base, 12 * T2);
     }
     function testNewAuction() {
         var (id, base) = newAuction();

--- a/contracts/tests/twoway.sol
+++ b/contracts/tests/twoway.sol
@@ -20,7 +20,7 @@ contract TwoWayTest is AuctionTest {
         expectEventsExact(manager);
         NewAuction(id, base);
         AuctionReversal(id);
-        Bid(base);
+        Bid(base, 101 * T2);
     }
     function testNewTwoWayAuction() {
         var (id, base) = newTwoWayAuction();
@@ -204,7 +204,7 @@ contract TwoWayMultipleBeneficiariesTest is AuctionTest
         expectEventsExact(manager);
         NewAuction(id, base);
         AuctionReversal(id);
-        Bid(base);
+        Bid(base, 101 * T2);
 
         assertEq(manager.isReversed(id), true);
     }


### PR DESCRIPTION
Changed the Bid event to include the bid price info, so that listeners in a harness language can get updates on the bid price. For example, an auction arbitrage bot needs the price info of bids in order to operate.

All 167 tests pass. Note that 4 tests were minimally altered, just by putting the bid price into the Bid event.

The documentation has also been updated to reflect this change.
