### PR TITLE
introduce per-auction expiry

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,8 @@ var (id, base) = manager.newAuction( beneficiary
   must be at least this much plus the minimum increase.
 - `uint min_increase` is the integer percentage amount that each bid
   must increase on the last by (in terms of `buy_token`).
-- `uint ttl` is the time after which a bid will be locked and
-  claimable by its highest bidder.
+- `uint ttl` is the time after the previous bid when a bid will be
+  locked and claimable by its highest bidder.
 
 
 Create a new **reverse** auction:
@@ -399,6 +399,38 @@ var (id, base) = manager.newTwoWayAuction( beneficiaries
 
 - `address refund` is the address that forgone `sell_token` will be
   sent to, continuously.
+
+
+### Finite duration auction
+
+The default behaviour is for a new auction to persist indefinitely,
+until bids have been made for all of the collateral. If there are no
+bids then the collateral will remain locked forever.
+
+The forward auction can take an extra argument that determines when
+the auction as a whole will expire. After this time, bids will be
+rejected and all collateral will be claimable by its last bidder. In
+the case of unbid collateral the last bidder is taken to be the
+first beneficiary, who will receive the collateral after a call to
+`claim`.
+
+Creating a finite-duration auction:
+
+```
+var (id, base) = manager.newAuction( beneficiary
+                                   , sell_token
+                                   , buy_token
+                                   , sell_amount
+                                   , start_bid
+                                   , min_increase
+                                   , ttl
+                                   , expiration
+                                   );
+```
+
+- `uint expiration` is the *absolute* time after which the auction
+  will be expired, i.e. not relative to the block timestamp on
+  creation.
 
 
 ## Gas costs

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ identifiers are used when bidding and claiming.
 Note: you will not be able to use named arguments on auction
 creation due to an upstream [solidity issue][name-args-issue].
 
-[named-args-issue]: TODO
+[named-args-issue]: https://github.com/ethereum/solidity/issues/637
 
 Create a new **forward** auction:
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ continually rewarded as new bids are made: by increasing amounts of
 the buy token in a forward auction, and by increasing amounts of
 forgone sell token in a reverse auction. Highest bidders are
 continually rewarded as well: bids are locked once they have existed
-for a given duration with no higher bids, at which point the highest
+for a given time with no higher bids, at which point the highest
 bidder can claim their dues.
 
 The auctions are **managed**. An auction manager can manage an
@@ -115,7 +115,7 @@ var (id, base) = manager.newAuction( beneficiary
                                    , sell_amount
                                    , start_bid
                                    , min_increase
-                                   , duration
+                                   , ttl
                                    )
 ```
 
@@ -131,7 +131,7 @@ var (id, base) = manager.newAuction( beneficiary
   must be at least this much plus the minimum increase.
 - `uint min_increase` is the integer percentage amount that each bid
   must increase on the last by (in terms of `buy_token`).
-- `uint duration` is the time after which a bid will be locked and
+- `uint ttl` is the time after which a bid will be locked and
   claimable by its highest bidder.
 
 
@@ -144,7 +144,7 @@ var (id, base) = manager.newReverseAuction( beneficiary
                                           , max_sell_amount
                                           , buy_amount
                                           , min_decrease
-                                          , duration
+                                          , ttl
                                           )
 ```
 
@@ -172,7 +172,7 @@ var (id, base) = manager.newTwoWayAuction( beneficiary
                                          , start_bid
                                          , min_increase
                                          , min_decrease
-                                         , duration
+                                         , ttl
                                          , collection_limit
                                          )
 ```
@@ -241,7 +241,7 @@ manager.claim(id)
 ```
 
 This will send the `sell_token` associated with `id` to the
-highest bidder. `claim` will throw if `duration` has not elapsed
+highest bidder. `claim` will throw if `ttl` has not elapsed
 since the last high bid on `id`.
 
 
@@ -309,7 +309,7 @@ var (id, base) = manager.newAuction( beneficiaries
                                    , sell_amount
                                    , start_bid
                                    , min_increase
-                                   , duration);
+                                   , ttl);
 ```
 
 - `address[] beneficiaries` is the array of beneficiary addresses
@@ -332,7 +332,7 @@ var (id, base) = manager.newTwoWayAuction( beneficiaries
                                          , start_bid
                                          , min_increase
                                          , min_decrease
-                                         , duration
+                                         , ttl
                                          );
 ```
 
@@ -361,7 +361,7 @@ var (id, base) = manager.newReverseAuction( beneficiary
                                           , max_sell_amount
                                           , buy_amount
                                           , min_decrease
-                                          , duration
+                                          , ttl
                                           )
 ```
 
@@ -376,7 +376,7 @@ var (id, base) = manager.newTwoWayAuction( beneficiary
                                          , start_bid
                                          , min_increase
                                          , min_decrease
-                                         , duration
+                                         , ttl
                                          , collection_limit
                                          )
 ```
@@ -393,7 +393,7 @@ var (id, base) = manager.newTwoWayAuction( beneficiaries
                                          , start_bid
                                          , min_increase
                                          , min_decrease
-                                         , duration
+                                         , ttl
                                          );
 ```
 

--- a/contracts/tests/base.sol
+++ b/contracts/tests/base.sol
@@ -23,7 +23,7 @@ contract TestableManager is SplittingAuctionManager {
     {
         Auction auction = _auctions[id];
         return (auction.beneficiaries[0], auction.selling, auction.buying,
-                auction.sell_amount, auction.start_bid, auction.min_increase, auction.duration);
+                auction.sell_amount, auction.start_bid, auction.min_increase, auction.ttl);
     }
     function getAuctionlet(uint id) constant
         returns (uint, address, uint, uint)

--- a/contracts/tests/db.sol
+++ b/contracts/tests/db.sol
@@ -23,9 +23,9 @@ contract CRUDTest is AuctionTest, AuctionDatabase {
     function testReadOnlyAuction() {
         var auction = readAuction(1);
 
-        assertEq(_auctions[1].duration, 0);
-        auction.duration = 100 years;
-        assertEq(_auctions[1].duration, 0);
+        assertEq(_auctions[1].ttl, 0);
+        auction.ttl = 100 years;
+        assertEq(_auctions[1].ttl, 0);
     }
     function testReadOnlyAuctionlet() {
         var auctionlet = readAuctionlet(1);
@@ -46,7 +46,7 @@ contract AuctionDBTest is AuctionTest {
                                  , 100 * T1  // sell_amount
                                  , 10 * T2   // start_bid
                                  , 1         // min_increase
-                                 , 1 years   // duration
+                                 , 1 years   // ttl
                                  );
     }
     function testDefaultRefund() {

--- a/contracts/tests/exploit.sol
+++ b/contracts/tests/exploit.sol
@@ -82,7 +82,7 @@ contract ExploitTest is AuctionTest {
                                  , 100 * T1  // sell_amount
                                  , 10 * TM   // start_bid
                                  , 1         // min_increase (%)
-                                 , 1 years   // duration
+                                 , 1 years   // ttl
                                  );
     }
     function newMaliciousClaimAuction() returns (uint, uint) {
@@ -92,7 +92,7 @@ contract ExploitTest is AuctionTest {
                                  , 100 * TM  // sell_amount
                                  , 10 * T2   // start_bid
                                  , 1         // min_increase (%)
-                                 , 1 years   // duration
+                                 , 1 years   // ttl
                                  );
     }
     function exploitSetUp () returns (uint) ;

--- a/contracts/tests/reverse.sol
+++ b/contracts/tests/reverse.sol
@@ -8,7 +8,7 @@ contract ReverseTest is AuctionTest {
                                         , 100 * T1  // max_sell_amount
                                         , 5 * T2    // buy_amount
                                         , 2         // min_decrease (%)
-                                        , 1 years   // duration
+                                        , 1 years   // ttl
                                         );
     }
     function testNewReverseAuction() {
@@ -141,7 +141,7 @@ contract MinBidDecreaseTest is AuctionTest {
                                         , 100 * T1  // max_sell_amount
                                         , 5 * T2    // buy_amount
                                         , 20        // min_decrease (%)
-                                        , 1 years   // duration
+                                        , 1 years   // ttl
                                         );
     }
     function testFailFirstBidEqualStartBid() {
@@ -173,7 +173,7 @@ contract ReverseRefundTest is AuctionTest {
                                         , 100 * T1      // max_sell_amount
                                         , 5 * T2        // buy_amount
                                         , 20            // min_decrease (%)
-                                        , 1 years       // duration
+                                        , 1 years       // ttl
                                         );
     }
     function testNewReverseAuction() {

--- a/contracts/tests/reverse_splitting.sol
+++ b/contracts/tests/reverse_splitting.sol
@@ -8,7 +8,7 @@ contract ReverseSplittingTest is AuctionTest {
                                         , 100 * T1  // sell_amount
                                         , 5 * T2    // buy_amount
                                         , 2         // min_decrease (%)
-                                        , 1 years   // duration
+                                        , 1 years   // ttl
                                         );
     }
     function testNewReverseAuction() {

--- a/contracts/tests/splitting_auction.sol
+++ b/contracts/tests/splitting_auction.sol
@@ -9,7 +9,7 @@ contract ForwardSplittingTest is AuctionTest
                                  , 100 * T1  // sell_amount
                                  , 10 * T2   // start_bid
                                  , 1         // min_increase (%)
-                                 , 1 years   // duration
+                                 , 1 years   // ttl
                                  );
     }
     function testSplitEvent() {
@@ -326,7 +326,7 @@ contract ForwardSplittingTest is AuctionTest
 
         var (nid, sid) = bidder1.doBid(base, 7 * T2, 60 * T1);
 
-        // push past the base auction duration
+        // push past the base auction ttl
         manager.addTime(2 years);
 
         // this should succeed as there are no real bidders
@@ -337,7 +337,7 @@ contract ForwardSplittingTest is AuctionTest
 
         var (nid, sid) = bidder1.doBid(base, 7 * T2, 60 * T1);
 
-        // push past the base auction duration
+        // push past the base auction ttl
         manager.addTime(2 years);
 
         // this should succeed as there are no real bidders

--- a/contracts/tests/twoway.sol
+++ b/contracts/tests/twoway.sol
@@ -9,7 +9,7 @@ contract TwoWayTest is AuctionTest {
                                        , 10 * T2   // start_bid
                                        , 1         // min_increase (%)
                                        , 1         // min_decrease (%)
-                                       , 1 years   // duration
+                                       , 1 years   // ttl
                                        , 100 * T2  // collection_limit
                                        );
     }
@@ -315,7 +315,7 @@ contract TwoWayRefundTest is AuctionTest {
                                                         , 10 * T2       // start_bid
                                                         , 1             // min_increase (%)
                                                         , 1             // min_decrease (%)
-                                                        , 1 years       // duration
+                                                        , 1 years       // ttl
                                                         , 100 * T2      // collection_limit
                                                         );
     }

--- a/contracts/types.sol
+++ b/contracts/types.sol
@@ -14,7 +14,8 @@ contract AuctionType {
         uint sell_amount;
         uint collected;
         uint collection_limit;
-        uint duration;
+        uint ttl;
+        uint expiration;
         bool reversed;
         uint unsold;
     }


### PR DESCRIPTION
fixes #49. Only available on the single beneficiary forward auction for now -
all others have the expiration implicitly set to infinity.
