### PR TITLE
upgrade to dapple 0.8 / solidity 0.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /build
+.dapple

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ env:
 
 before_install:
   - id
-  - if [ $TEST = "dapple" ]; then npm install --progress=false -g dapple@0.7.2; fi
-  - if [ $TEST = "dapple" ]; then wget https://github.com/rainbeam/solidity-static/releases/download/v0.3.6/solc; fi
+  - if [ $TEST = "dapple" ]; then npm install --progress=false -g dapple; fi
+  - if [ $TEST = "dapple" ]; then wget https://github.com/rainbeam/solidity-static/releases/download/v0.4.2-rel/solc; fi
   - if [ $TEST = "dapple" ]; then sudo install solc /usr/local/bin/; fi
   - cp .travis.dapplerc $HOME/.dapplerc
 

--- a/contracts/auction.sol
+++ b/contracts/auction.sol
@@ -1,3 +1,5 @@
+pragma solidity ^0.4.0;
+
 import 'db.sol';
 import 'events.sol';
 import 'types.sol';

--- a/contracts/db.sol
+++ b/contracts/db.sol
@@ -1,3 +1,5 @@
+pragma solidity ^0.4.0;
+
 import 'types.sol';
 import 'util.sol';
 import 'erc20/erc20.sol';

--- a/contracts/events.sol
+++ b/contracts/events.sol
@@ -1,3 +1,5 @@
+pragma solidity ^0.4.0;
+
 contract EventfulAuction {
     event LogBid(uint indexed auctionlet_id);
     event LogSplit(uint base_id, uint new_id, uint split_id);

--- a/contracts/manager.sol
+++ b/contracts/manager.sol
@@ -1,3 +1,5 @@
+pragma solidity ^0.4.0;
+
 import 'erc20/erc20.sol';
 
 import 'auction.sol';

--- a/contracts/tests/auction_manager.sol
+++ b/contracts/tests/auction_manager.sol
@@ -1,3 +1,5 @@
+pragma solidity ^0.4.0;
+
 import 'tests/base.sol';
 
 contract AuctionManagerTest is AuctionTest {

--- a/contracts/tests/auction_manager.sol
+++ b/contracts/tests/auction_manager.sol
@@ -2,11 +2,14 @@ pragma solidity ^0.4.0;
 
 import 'tests/base.sol';
 
-contract AuctionManagerTest is AuctionTest {
+contract SetUpTest is AuctionTest {
     function testSetUp() {
         assertEq(t2.balanceOf(bidder1), 1000 * T2);
         assertEq(t2.allowance(bidder1, manager), 1000 * T2);
     }
+}
+
+contract NewAuctionTest is AuctionTest {
     function newAuction() returns (uint, uint) {
         return manager.newAuction( seller    // beneficiary
                                  , t1        // selling
@@ -22,16 +25,6 @@ contract AuctionManagerTest is AuctionTest {
 
         expectEventsExact(manager);
         LogNewAuction(id, base);
-    }
-    function testBidEvent() {
-        var (id, base) = newAuction();
-        bidder1.doBid(base, 11 * T2);
-        bidder2.doBid(base, 12 * T2);
-
-        expectEventsExact(manager);
-        LogNewAuction(id, base);
-        LogBid(base);
-        LogBid(base);
     }
     function testNewAuction() {
         var (id, base) = newAuction();
@@ -75,6 +68,29 @@ contract AuctionManagerTest is AuctionTest {
         assertEq(last_bidder, seller);
         assertEq(buy_amount, 10 * T2);
         assertEq(sell_amount, 100 * T1);
+    }
+}
+
+contract BidTest is AuctionTest {
+    function newAuction() returns (uint, uint) {
+        return manager.newAuction( seller    // beneficiary
+                                 , t1        // selling
+                                 , t2        // buying
+                                 , 100 * T1  // sell_amount
+                                 , 10 * T2   // start_bid
+                                 , 1         // min_increase (%)
+                                 , 1 years   // ttl
+                                 );
+    }
+    function testBidEvent() {
+        var (id, base) = newAuction();
+        bidder1.doBid(base, 11 * T2);
+        bidder2.doBid(base, 12 * T2);
+
+        expectEventsExact(manager);
+        LogNewAuction(id, base);
+        LogBid(base);
+        LogBid(base);
     }
     function testFailBidUnderMinBid() {
         var (id, base) = newAuction();
@@ -144,6 +160,28 @@ contract AuctionManagerTest is AuctionTest {
 
         assertEq(balance_after - balance_before, 40 * T2);
     }
+    function testBidTransfersToDistinctBeneficiary() {
+        var (id, base) = manager.newAuction(bidder2, t1, t2, 100 * T1, 0 * T2, 1, 1 years);
+
+        var balance_before = t2.balanceOf(bidder2);
+        bidder1.doBid(base, 10 * T2);
+        var balance_after = t2.balanceOf(bidder2);
+
+        assertEq(balance_after - balance_before, 10 * T2);
+    }
+}
+
+contract MultipleAuctionTest is AuctionTest {
+    function newAuction() returns (uint, uint) {
+        return manager.newAuction( seller    // beneficiary
+                                 , t1        // selling
+                                 , t2        // buying
+                                 , 100 * T1  // sell_amount
+                                 , 10 * T2   // start_bid
+                                 , 1         // min_increase (%)
+                                 , 1 years   // ttl
+                                 );
+    }
     function testMultipleNewAuctions() {
         // auction manager should be able to manage multiple auctions
         t2.transfer(seller, 200 * T2);
@@ -197,15 +235,6 @@ contract AuctionManagerTest is AuctionTest {
         var balance_after = t1.balanceOf(this);
 
         assertEq(balance_before - balance_after, 200 * T1);
-    }
-    function testBidTransfersToDistinctBeneficiary() {
-        var (id, base) = manager.newAuction(bidder2, t1, t2, 100 * T1, 0 * T2, 1, 1 years);
-
-        var balance_before = t2.balanceOf(bidder2);
-        bidder1.doBid(base, 10 * T2);
-        var balance_after = t2.balanceOf(bidder2);
-
-        assertEq(balance_after - balance_before, 10 * T2);
     }
 }
 

--- a/contracts/tests/base.sol
+++ b/contracts/tests/base.sol
@@ -1,3 +1,5 @@
+pragma solidity ^0.4.0;
+
 import 'dapple/test.sol';
 import 'erc20/base.sol';
 import 'manager.sol';

--- a/contracts/tests/base.sol
+++ b/contracts/tests/base.sol
@@ -1,7 +1,10 @@
 pragma solidity ^0.4.0;
 
 import 'dapple/test.sol';
+
 import 'erc20/base.sol';
+
+import 'events.sol';
 import 'manager.sol';
 import 'types.sol';
 
@@ -76,42 +79,38 @@ contract AuctionTest is EventfulAuction, EventfulManager, Test {
     uint constant T2 = 7 ** 10;
 
     uint constant INFINITY = uint(uint128(-1));
+    uint constant million = 10 ** 6;
 
-    function setUp() {
+    function AuctionTest() {
         manager = new TestableManager();
-        manager.setTime(block.timestamp);
-
-        var million = 10 ** 6;
 
         t1 = new ERC20Base(million * T1);
         t2 = new ERC20Base(million * T2);
 
         seller = new AuctionTester();
-        seller.bindManager(manager);
-
-        t1.transfer(seller, 200 * T1);
-        seller.doApprove(manager, 200 * T1, t1);
-
         bidder1 = new AuctionTester();
-        bidder1.bindManager(manager);
-
-        t2.transfer(bidder1, 1000 * T2);
-        bidder1.doApprove(manager, 1000 * T2, t2);
-
         bidder2 = new AuctionTester();
-        bidder2.bindManager(manager);
+        beneficiary1 = new AuctionTester();
+        beneficiary2 = new AuctionTester();
 
-        t2.transfer(bidder2, 1000 * T2);
-        bidder2.doApprove(manager, 1000 * T2, t2);
+        manager.setTime(block.timestamp);
+
+        seller.bindManager(manager);
+        bidder1.bindManager(manager);
+        bidder2.bindManager(manager);
+        beneficiary1.bindManager(manager);
+        beneficiary2.bindManager(manager);
 
         t1.transfer(this, 1000 * T1);
         t2.transfer(this, 1000 * T2);
+        t1.transfer(seller, 200 * T1);
+        t2.transfer(bidder1, 1000 * T2);
+        t2.transfer(bidder2, 1000 * T2);
+
+        seller.doApprove(manager, 200 * T1, t1);
+        bidder1.doApprove(manager, 1000 * T2, t2);
+        bidder2.doApprove(manager, 1000 * T2, t2);
         t1.approve(manager, 1000 * T1);
         t2.approve(manager, 1000 * T2);
-
-        beneficiary1 = new AuctionTester();
-        beneficiary1.bindManager(manager);
-        beneficiary2 = new AuctionTester();
-        beneficiary2.bindManager(manager);
     }
 }

--- a/contracts/tests/db.sol
+++ b/contracts/tests/db.sol
@@ -1,3 +1,5 @@
+pragma solidity ^0.4.0;
+
 import 'tests/base.sol';
 import 'db.sol';
 

--- a/contracts/tests/exploit.sol
+++ b/contracts/tests/exploit.sol
@@ -1,3 +1,5 @@
+pragma solidity ^0.4.0;
+
 import 'erc20/base.sol';
 import 'tests/base.sol';
 

--- a/contracts/tests/exploit.sol
+++ b/contracts/tests/exploit.sol
@@ -97,7 +97,8 @@ contract ExploitTest is AuctionTest {
                                  , 1 years   // ttl
                                  );
     }
-    function exploitSetUp () returns (uint) ;
+    function exploitSetUp () returns (uint) {
+    }
     function testSetUp() {
         exploitSetUp();
     }

--- a/contracts/tests/gas.sol
+++ b/contracts/tests/gas.sol
@@ -1,3 +1,5 @@
+pragma solidity ^0.4.0;
+
 import 'tests/base.sol';
 
 

--- a/contracts/tests/gas.sol
+++ b/contracts/tests/gas.sol
@@ -7,15 +7,15 @@ contract ForwardGasTest is AuctionTest {
 
     modifier pre_create {
         (id, base) = newAuction();
-        _
+        _;
     }
     modifier pre_bid(uint how_much) {
         bidder1.doBid(base, how_much);
-        _
+        _;
     }
     modifier force_expiry {
         manager.addTime(100 years);
-        _
+        _;
     }
     function newAuction() returns (uint, uint) {
         return manager.newAuction(beneficiary1, t1, t2, 100 * T1, 0, 1, 1 hours);
@@ -72,15 +72,15 @@ contract ReverseGasTest is AuctionTest {
 
     modifier pre_create {
         (id, base) = newAuction();
-        _
+        _;
     }
     modifier pre_bid(uint how_much) {
         bidder1.doBid(base, how_much);
-        _
+        _;
     }
     modifier force_expiry {
         manager.addTime(100 years);
-        _
+        _;
     }
     function newAuction() returns (uint, uint) {
         return manager.newReverseAuction(beneficiary1, t1, t2, 100 * T1, 100 * T2, 1, 1 hours);
@@ -137,11 +137,11 @@ contract TwoWayGasTest is AuctionTest {
 
     modifier pre_create {
         (id, base) = newAuction();
-        _
+        _;
     }
     modifier pre_bid(uint how_much) {
         bidder1.doBid(base, how_much);
-        _
+        _;
     }
     function newAuction() returns (uint, uint) {
         return manager.newTwoWayAuction(beneficiary1, t1, t2, 100 * T1, 10 * T2, 1, 1, 1 hours, 50 * T2);

--- a/contracts/tests/reverse.sol
+++ b/contracts/tests/reverse.sol
@@ -1,3 +1,5 @@
+pragma solidity ^0.4.0;
+
 import 'tests/base.sol';
 
 contract ReverseTest is AuctionTest {

--- a/contracts/tests/reverse_splitting.sol
+++ b/contracts/tests/reverse_splitting.sol
@@ -1,3 +1,5 @@
+pragma solidity ^0.4.0;
+
 import 'tests/base.sol';
 
 contract ReverseSplittingTest is AuctionTest {

--- a/contracts/tests/splitting_auction.sol
+++ b/contracts/tests/splitting_auction.sol
@@ -1,3 +1,5 @@
+pragma solidity ^0.4.0;
+
 import 'tests/base.sol';
 
 contract ForwardSplittingTest is AuctionTest

--- a/contracts/tests/twoway.sol
+++ b/contracts/tests/twoway.sol
@@ -1,3 +1,5 @@
+pragma solidity ^0.4.0;
+
 import 'tests/base.sol';
 
 contract TwoWayTest is AuctionTest {

--- a/contracts/transfer.sol
+++ b/contracts/transfer.sol
@@ -1,3 +1,5 @@
+pragma solidity ^0.4.0;
+
 import 'types.sol';
 import 'util.sol';
 

--- a/contracts/types.sol
+++ b/contracts/types.sol
@@ -1,3 +1,5 @@
+pragma solidity ^0.4.0;
+
 import 'erc20/erc20.sol';
 
 contract AuctionType {

--- a/contracts/util.sol
+++ b/contracts/util.sol
@@ -1,3 +1,5 @@
+pragma solidity ^0.4.0;
+
 contract Assertive {
     function assert(bool what) internal {
         if (!what) {

--- a/contracts/util.sol
+++ b/contracts/util.sol
@@ -69,7 +69,7 @@ contract MutexUser {
     modifier exclusive {
         if (mutex_lock) throw;
         mutex_lock = true;
-        _
+        _;
         mutex_lock = false;
     }
 }

--- a/dappfile
+++ b/dappfile
@@ -3,19 +3,22 @@ tags: []
 layout:
   sol_sources: contracts
   build_dir: build
+  packages_directory: dapple_packages
 dependencies:
   erc20: 1.0.0
 ignore: []
 name: token-auction
 environments:
-  default: morden
   morden:
     objects:
       auction:
-        class: SplittingAuctionManager
-        address: '0x6b4ae8fa2fd6cbe715e89b1f0df9d952ea97d7a9'
+        type: SplittingAuctionManager
+        value: '0x6b4ae8fa2fd6cbe715e89b1f0df9d952ea97d7a9'
+    type: MORDEN
   live:
     objects:
       auction:
-        class: SplittingAuctionManager
-        address: '0x7f6eccbca710e8b5af7d837c7e2e406844538e10'
+        type: SplittingAuctionManager
+        value: '0x7f6eccbca710e8b5af7d837c7e2e406844538e10'
+    type: MORDEN
+dapple_version: 0.8.3

--- a/dappfile
+++ b/dappfile
@@ -21,4 +21,7 @@ environments:
         type: SplittingAuctionManager
         value: '0x7f6eccbca710e8b5af7d837c7e2e406844538e10'
     type: MORDEN
+  dev:
+    objects: {}
+    type: internal
 dapple_version: 0.8.3


### PR DESCRIPTION
Fixes #57, #55.

TODO:
- [x] add solidity version pragma "pragma solidity ^0.4.2;"
- [x] fix test contract deployment failures (throw on deploy) [pending ethereumjs-vm update]
- [x] rebase and update ci

The latter appears to be dapple / solidity issue, probably exposed by the largish setUp method in the auction tests (which creates several new contracts).

The global setUp method could be replaced by some use of dapple script - this would set the initial chain state from which each unit test would fork from.
