### PR TITLE
use 128 bits as our definition of very large

### DIFF
--- a/contracts/db.sol
+++ b/contracts/db.sol
@@ -205,7 +205,7 @@ contract AuctionDatabaseUser is AuctionDatabase, SafeMathUser, TimeUser {
         auction.min_increase = min_increase;
         auction.min_decrease = min_decrease;
         auction.ttl = ttl;
-        auction.expiration = uint(-1);  // infinity
+        auction.expiration = uint(uint128(-1));  // 'infinity'
         auction.collection_limit = collection_limit;
         auction.unsold = sell_amount;
 

--- a/contracts/manager.sol
+++ b/contracts/manager.sol
@@ -81,7 +81,7 @@ contract AuctionController is MathUser
 }
 
 contract AuctionManagerFrontend is AuctionController, MutexUser {
-    uint constant INFINITY = uint(-1);
+    uint constant INFINITY = uint(uint128(-1));
     // Create a new forward auction.
     // Bidding is done through the auctions associated auctionlets,
     // of which there is one initially.

--- a/contracts/tests/base.sol
+++ b/contracts/tests/base.sol
@@ -73,7 +73,7 @@ contract AuctionTest is EventfulAuction, EventfulManager, Test {
     uint constant T1 = 5 ** 12;
     uint constant T2 = 7 ** 10;
 
-    uint constant INFINITY = uint(-1);
+    uint constant INFINITY = uint(uint128(-1));
 
     function setUp() {
         manager = new TestableManager();


### PR DESCRIPTION
Using 256 bits leaves not enough room to deal with e.g. temporarily
overflowing multiplication. If users want more than 2**128 units, maybe
they have bigger problems than can be addressed here.
